### PR TITLE
AsmMethodRemapper assigns names to local variables

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
@@ -19,6 +19,7 @@ package net.fabricmc.tinyremapper;
 
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Handle;
+import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -39,6 +40,56 @@ class AsmClassRemapper extends ClassRemapper {
 	private static class AsmMethodRemapper extends MethodRemapper {
 		public AsmMethodRemapper(MethodVisitor mv, Remapper remapper) {
 			super(mv, remapper);
+		}
+
+		private String baseTypeName(String descriptor) {
+			switch (descriptor.charAt(0)) {
+				case 'B':
+					return "byte";
+				case 'C':
+					return "char";
+				case 'D':
+					return "double";
+				case 'F':
+					return "float";
+				case 'I':
+					return "int";
+				case 'J':
+					return "long";
+				case 'S':
+					return "short";
+				case 'Z':
+					return "boolean";
+				case 'V':
+					return "void";
+				case '[':
+					int idx = 1;
+					while(descriptor.charAt(idx) == '[') idx += 1;
+					String s = "array";
+					if(idx > 1) s += idx + "D";
+
+					return s + titleCase(baseTypeName(descriptor.substring(1)));
+				case 'L':
+					String name = descriptor.substring(1, descriptor.length() - 1);
+					name = remapper.mapType(name);
+					return name.substring(name.lastIndexOf('/')+1, name.length());
+
+			}
+			return "var";
+		}
+
+		private String titleCase(String s) {
+			char[] chars = s.toCharArray();
+			chars[0] = Character.toTitleCase(chars[0]);
+			return new String(chars);
+		}
+
+		@Override
+		public void visitLocalVariable(String name, String descriptor, String signature, Label start, Label end, int index) {
+			if(name.startsWith("\u2603")) {
+				name = baseTypeName(descriptor) + "_" + index;
+			}
+			super.visitLocalVariable(name, descriptor, signature, start, end, index);
 		}
 
 		@Override


### PR DESCRIPTION
The resulting mapped jars no longer have snowmen for locals.

Kind of a short term solution since locals/args in mapping files are currently ignored.