### PR TITLE
Fix member descriptors when the from namespace isn't first

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
@@ -314,8 +314,8 @@ public final class TinyUtils {
 
 					if (!mappedName.isEmpty()) {
 						out.acceptClass(className, mappedName);
-						if (obfFrom != null) obfFrom.put(unescapeOpt(parts[1], escapedNames), mappedName);
 					}
+					if (obfFrom != null) obfFrom.put(unescapeOpt(parts[1], escapedNames), className);
 
 					inClass = true;
 				}

--- a/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
@@ -315,6 +315,7 @@ public final class TinyUtils {
 					if (!mappedName.isEmpty()) {
 						out.acceptClass(className, mappedName);
 					}
+
 					if (obfFrom != null) obfFrom.put(unescapeOpt(parts[1], escapedNames), className);
 
 					inClass = true;


### PR DESCRIPTION
Previously mapped member descriptors to the `to` namespace instead, which isn't how `IMappingProvider` is designed to take them (as it would be odd to have the `from` namespace name with the `to` namespace descriptor).