### PR TITLE
Prevent keywords or literals being used as local var names

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import javax.lang.model.SourceVersion;
+
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
@@ -506,16 +508,7 @@ class AsmClassRemapper extends ClassRemapper {
 
 		private static boolean isValidJavaIdentifier(String s) {
 			if (s == null || s.isEmpty()) return false;
-
-			int cp = s.codePointAt(0);
-			if (!Character.isJavaIdentifierStart(cp)) return false;
-
-			for (int i = Character.charCount(cp), max = s.length(); i < max; i += Character.charCount(cp)) {
-				cp = s.codePointAt(i);
-				if (!Character.isJavaIdentifierPart(cp)) return false;
-			}
-
-			return true;
+			return SourceVersion.isName(s);
 		}
 
 		private static final String[] singleCharStrings = {


### PR DESCRIPTION
Previously `AsmClassRemapper` could create local var names which are keywords or literals, or it would not consider existing variable names which are keywords or literals as invalid.

It now uses [SourceVersion.isName](https://docs.oracle.com/javase/8/docs/api/javax/lang/model/SourceVersion.html#isName-java.lang.CharSequence-) to detect invalid names, whose behavior sadly depends on the running Java version. In Java 9(+) this can be solved by using the [method overload](https://docs.oracle.com/en/java/javase/11/docs/api/java.compiler/javax/lang/model/SourceVersion.html#isName(java.lang.CharSequence,javax.lang.model.SourceVersion)) which accepts a `SourceVersion`.

[test.zip](https://github.com/FabricMC/tiny-remapper/files/4051303/test.zip) contains a class file for which tiny-remapper would previously create invalid parameter names.
