### PR TITLE
Fix variable names containing ignorable chars not being renamed

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
@@ -545,7 +545,10 @@ class AsmClassRemapper extends ClassRemapper {
 		}
 
 		private static boolean isValidJavaIdentifier(String s) {
-			return s != null && !s.isEmpty() && SourceVersion.isIdentifier(s);
+			return s != null && !s.isEmpty() && SourceVersion.isIdentifier(s)
+					// Ignorable characters cannot be represented in source code,
+					// would be ignored when re-compiled
+					&& !s.codePoints().anyMatch(Character::isIdentifierIgnorable);
 		}
 
 		private static boolean isJavaKeyword(String s) {


### PR DESCRIPTION
Ignorable chars (`Character.isIdentifierIgnorable`) are ignored as part of identifiers (cannot be leading, but can be in between and trailing) when compiling. They can therefore normally not appear in a class file unless it was modified. Since they cannot be represented in source (and could easily cause identifier collisions), identifiers containing them are now considered invalid.

This was only added to the JLS for Java 10 (see [JDK-6214519](https://bugs.openjdk.java.net/browse/JDK-6214519)), however the behavior also exists in earlier versions.

Demonstration of the issue:
1. Download [IdentifierIgnorable.class.txt](https://github.com/FabricMC/tiny-remapper/files/4566792/IdentifierIgnorable.class.txt) (remove `.txt`, that is only to make GitHub happy)
2. Use Tiny Remapper and let it rename invalid variable names
