### PR TITLE
Allow threads to be configurable from the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.gradle
 *.jar
 *.tiny
+.idea/

--- a/src/main/java/net/fabricmc/tinyremapper/Main.java
+++ b/src/main/java/net/fabricmc/tinyremapper/Main.java
@@ -48,6 +48,7 @@ public class Main {
 		boolean skipLocalVariableMapping = false;
 		boolean renameInvalidLocals = false;
 		NonClassCopyMode ncCopyMode = NonClassCopyMode.FIX_META_INF;
+		int threads = -1;
 
 		for (String arg : rawArgs) {
 			if (arg.startsWith("--")) {
@@ -104,6 +105,13 @@ public class Main {
 						System.exit(1);
 					}
 
+					break;
+				case "threads":
+					threads = Integer.parseInt(arg.substring(valueSepPos + 1));
+					if (threads <= 0) {
+						System.out.println("Thread count must be > 0");
+						System.exit(1);
+					}
 					break;
 				default:
 					System.out.println("invalid argument: "+arg+".");
@@ -185,6 +193,7 @@ public class Main {
 				.rebuildSourceFilenames(rebuildSourceFilenames)
 				.skipLocalVariableMapping(skipLocalVariableMapping)
 				.renameInvalidLocals(renameInvalidLocals)
+				.threads(threads)
 				.build();
 
 		try (OutputConsumerPath outputConsumer = new OutputConsumerPath.Builder(output).build()) {


### PR DESCRIPTION
This relates to, but is technically separate from #44. That issue was the motivation for this PR.

Other than determining threading issues and being able to mitigate them when they happen, this is nice to have in general from a user experience standpoint.

I also added `.idea/` to `.gitignore` because that was annoying me.