### PR TITLE
Only use same variable name for variables of same type

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
@@ -422,6 +422,7 @@ final class AsmClassRemapper extends VisitTrackingClassRemapper {
 
 									if (otherLv.index == lv.index
 											&& otherLv.name != null
+											&& otherLv.desc.equals(lv.desc)
 											&& (j < i || isValidLvName(otherLv.name))) {
 										lv.name = otherLv.name;
 										continue lvLoop;


### PR DESCRIPTION
Follow-up for 9c9bc0262e7e003fe9bd5d4268636e86995ea58e

Otherwise variables end up with completely unrelated names, e.g. exception variable of `catch` clause using name of variable declared inside `try` block.

Resolves #32 (actually 9c9bc0262e7e003fe9bd5d4268636e86995ea58e already resolved that)