### PR TITLE
Make V1 reader not discard trailing empty values

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
@@ -171,8 +171,8 @@ public final class TinyUtils {
 				tmp,
 				(remapClasses, classMapper) -> {
 					for (Member m : members) {
+						if (remapClasses) m.owner = classMapper.map(m.owner);
 						if (!m.owner.isEmpty()) {
-							if (remapClasses) m.owner = classMapper.map(m.owner);
 							m.desc = classMapper.mapDesc(m.desc);
 						}
 					}

--- a/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
@@ -139,31 +139,41 @@ public final class TinyUtils {
 		MappingAcceptor tmp = new MappingAcceptor() {
 			@Override
 			public void acceptClass(String srcName, String dstName) {
-				out.acceptClass(srcName, dstName);
+				if (!dstName.isEmpty()) {
+					out.acceptClass(srcName, dstName);
+				}
 			}
 
 			@Override
 			public void acceptMethod(Member method, String dstName) {
-				methodMappings.add(new MemberMapping(method, dstName));
-				members.add(method);
+				if (!dstName.isEmpty()) {
+					methodMappings.add(new MemberMapping(method, dstName));
+					members.add(method);
+				}
 			}
 
 			@Override
 			public void acceptMethodArg(Member method, int lvIndex, String dstName) {
-				methodArgMappings.add(new MethodArgMapping(method, lvIndex, dstName));
-				members.add(method);
+				if (!dstName.isEmpty()) {
+					methodArgMappings.add(new MethodArgMapping(method, lvIndex, dstName));
+					members.add(method);
+				}
 			}
 
 			@Override
 			public void acceptMethodVar(Member method, int lvIndex, int startOpIdx, int asmIndex, String dstName) {
-				methodVarMappings.add(new MethodVarMapping(method, lvIndex, startOpIdx, asmIndex, dstName));
-				members.add(method);
+				if (!dstName.isEmpty()) {
+					methodVarMappings.add(new MethodVarMapping(method, lvIndex, startOpIdx, asmIndex, dstName));
+					members.add(method);
+				}
 			}
 
 			@Override
 			public void acceptField(Member field, String dstName) {
-				fieldMappings.add(new MemberMapping(field, dstName));
-				members.add(field);
+				if (!dstName.isEmpty()) {
+					fieldMappings.add(new MemberMapping(field, dstName));
+					members.add(field);
+				}
 			}
 		};
 
@@ -172,14 +182,7 @@ public final class TinyUtils {
 				(remapClasses, classMapper) -> {
 					for (Member m : members) {
 						if (remapClasses) m.owner = classMapper.map(m.owner);
-						if (!m.owner.isEmpty()) {
-							try {
-								m.desc = classMapper.mapDesc(m.desc);
-							} catch (Exception e) {
-								e.printStackTrace();
-								// lazy temp thing to allow me to test more
-							}
-						}
+						m.desc = classMapper.mapDesc(m.desc);
 					}
 				});
 

--- a/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2018, Player, asie
- * Copyright (c) 2016, 2021, FabricMC
+ * Copyright (c) 2016, 2022, FabricMC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
@@ -173,7 +173,12 @@ public final class TinyUtils {
 					for (Member m : members) {
 						if (remapClasses) m.owner = classMapper.map(m.owner);
 						if (!m.owner.isEmpty()) {
-							m.desc = classMapper.mapDesc(m.desc);
+							try {
+								m.desc = classMapper.mapDesc(m.desc);
+							} catch (Exception e) {
+								e.printStackTrace();
+								// lazy temp thing to allow me to test more
+							}
 						}
 					}
 				});

--- a/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
@@ -139,41 +139,31 @@ public final class TinyUtils {
 		MappingAcceptor tmp = new MappingAcceptor() {
 			@Override
 			public void acceptClass(String srcName, String dstName) {
-				if (!dstName.isEmpty()) {
-					out.acceptClass(srcName, dstName);
-				}
+				out.acceptClass(srcName, dstName);
 			}
 
 			@Override
 			public void acceptMethod(Member method, String dstName) {
-				if (!dstName.isEmpty()) {
-					methodMappings.add(new MemberMapping(method, dstName));
-					members.add(method);
-				}
+				methodMappings.add(new MemberMapping(method, dstName));
+				members.add(method);
 			}
 
 			@Override
 			public void acceptMethodArg(Member method, int lvIndex, String dstName) {
-				if (!dstName.isEmpty()) {
-					methodArgMappings.add(new MethodArgMapping(method, lvIndex, dstName));
-					members.add(method);
-				}
+				methodArgMappings.add(new MethodArgMapping(method, lvIndex, dstName));
+				members.add(method);
 			}
 
 			@Override
 			public void acceptMethodVar(Member method, int lvIndex, int startOpIdx, int asmIndex, String dstName) {
-				if (!dstName.isEmpty()) {
-					methodVarMappings.add(new MethodVarMapping(method, lvIndex, startOpIdx, asmIndex, dstName));
-					members.add(method);
-				}
+				methodVarMappings.add(new MethodVarMapping(method, lvIndex, startOpIdx, asmIndex, dstName));
+				members.add(method);
 			}
 
 			@Override
 			public void acceptField(Member field, String dstName) {
-				if (!dstName.isEmpty()) {
-					fieldMappings.add(new MemberMapping(field, dstName));
-					members.add(field);
-				}
+				fieldMappings.add(new MemberMapping(field, dstName));
+				members.add(field);
 			}
 		};
 
@@ -243,7 +233,7 @@ public final class TinyUtils {
 
 			if ("CLASS".equals(type)) {
 				out.acceptClass(splitLine[1 + fromIndex], splitLine[1 + toIndex]);
-				if (obfFrom != null) obfFrom.put(splitLine[1], splitLine[1 + fromIndex]);
+				if (obfFrom != null && !splitLine[1 + fromIndex].isEmpty()) obfFrom.put(splitLine[1], splitLine[1 + fromIndex]);
 			} else {
 				boolean isMethod;
 
@@ -261,10 +251,12 @@ public final class TinyUtils {
 				String nameTo = splitLine[3 + toIndex];
 				Member member = new Member(owner, name, desc);
 
-				if (isMethod) {
-					out.acceptMethod(member, nameTo);
-				} else {
-					out.acceptField(member, nameTo);
+				if (!nameTo.isEmpty()) {
+					if (isMethod) {
+						out.acceptMethod(member, nameTo);
+					} else {
+						out.acceptField(member, nameTo);
+					}
 				}
 			}
 		}

--- a/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
@@ -226,7 +226,7 @@ public final class TinyUtils {
 		String line;
 
 		while ((line = reader.readLine()) != null) {
-			String[] splitLine = line.split("\t");
+			String[] splitLine = line.split("\t", -1);
 			if (splitLine.length < 2) continue;
 
 			String type = splitLine[0];

--- a/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
@@ -171,8 +171,10 @@ public final class TinyUtils {
 				tmp,
 				(remapClasses, classMapper) -> {
 					for (Member m : members) {
-						if (remapClasses) m.owner = classMapper.map(m.owner);
-						m.desc = classMapper.mapDesc(m.desc);
+						if (!m.owner.isEmpty()) {
+							if (remapClasses) m.owner = classMapper.map(m.owner);
+							m.desc = classMapper.mapDesc(m.desc);
+						}
 					}
 				});
 


### PR DESCRIPTION
Fixes support for some jar mapping and merging stuff in cases related to pre 1.3.1 versions, which would be really nice to get working in upstream loom at some point, and this is the 0th step for getting that to be a reality.