### PR TITLE
Fix #87

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
@@ -255,8 +255,9 @@ final class AsmClassRemapper extends VisitTrackingClassRemapper {
 			}
 
 			AsmRemapper asmRemapper = ((AsmRemapper) remapper);
+
 			for (ClassInstance checkClass = asmRemapper.getClass(owner); checkClass != null; checkClass = checkClass.getSuperClass()) {
-				if(checkClass.getMethod(name, descriptor) != null) {
+				if (checkClass.getMethod(name, descriptor) != null) {
 					owner = checkClass.getName();
 					break;
 				}

--- a/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
@@ -254,6 +254,14 @@ final class AsmClassRemapper extends VisitTrackingClassRemapper {
 				PackageAccessChecker.checkMember(this.owner, owner, name, descriptor, TrMember.MemberType.METHOD, "method instruction", (AsmRemapper) remapper);
 			}
 
+			AsmRemapper asmRemapper = ((AsmRemapper) remapper);
+			for (ClassInstance checkClass = asmRemapper.getClass(owner); checkClass != null; checkClass = checkClass.getSuperClass()) {
+				if(checkClass.getMethod(name, descriptor) != null) {
+					owner = checkClass.getName();
+					break;
+				}
+			}
+
 			super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
 		}
 


### PR DESCRIPTION
This PR fixes the issue [Wrong remap of super method with local static method of same name #87](https://github.com/FabricMC/tiny-remapper/issues/87), so using tiny remapper on Windows should work properly.

Fix code provided by my friend who is unable to create a GitHub account.
