### PR TITLE
Multithreaded TinyRemapper#apply

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/TinyRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyRemapper.java
@@ -979,7 +979,9 @@ public class TinyRemapper {
 	}
 	
 	private <T> void executeThreaded(Collection<T> list, Consumer<T> consumer) {
-		if(this.threadPool == ForkJoinPool.commonPool()) { // the pool used by Stream#parallel, perhaps it's best to leave the threading to java
+		// the pool used by Stream#parallel, it's best to leave the threading to java
+		//  made in preparation for custom thread pools
+		if(this.threadPool == ForkJoinPool.commonPool()) {
 			list.parallelStream().forEach(consumer);
 		} else {
 			List<Future<?>> futures = new ArrayList<>(outputBuffer.size());


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28693059/174216664-44363433-c824-43e8-abc3-292ea4d1901b.png)
The singlethreaded-ness of TinyRemapper#apply is a sore point in my code at the moment. There are 2 issues with the current system that the following pull request fixes:
 - The consumer is called on the main thread only
 - Writing the classes is not done in the same step as calling the consumer due to limitations in the API surface

I fix this by
 - Passing the input tags of a class into the consumer method, making it much easier to use apply and write every file at once.
 - Multithreading the apply method