### PR TITLE
Avoid requiring identical fs in MetaInfFixer

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/MetaInfFixer.java
+++ b/src/main/java/net/fabricmc/tinyremapper/MetaInfFixer.java
@@ -53,7 +53,7 @@ public class MetaInfFixer implements OutputConsumerPath.ResourceRemapper {
 			Manifest manifest = new Manifest(input);
 			fixManifest(manifest, remapper);
 
-			Path outputFile = destinationDirectory.resolve(relativePath);
+			Path outputFile = destinationDirectory.resolve(relativePath.toString());
 			Path outputDir = outputFile.getParent();
 			if (outputDir != null) Files.createDirectories(outputDir);
 
@@ -61,7 +61,7 @@ public class MetaInfFixer implements OutputConsumerPath.ResourceRemapper {
 				manifest.write(os);
 			}
 		} else if (remapper != null && relativePath.getNameCount() == 3 && relativePath.getName(1).toString().equals("services")) {
-			Path outputDir = destinationDirectory.resolve(relativePath).getParent();
+			Path outputDir = destinationDirectory.resolve(relativePath.toString()).getParent();
 			Files.createDirectories(outputDir);
 			Path outputFile = outputDir.resolve(mapFullyQualifiedClassName(fileName, remapper));
 


### PR DESCRIPTION
Uses the same workaround as in OutputConsumerPath