### PR TITLE
Only open JAR files if the provided input is a directory

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/TinyRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyRemapper.java
@@ -475,17 +475,14 @@ public class TinyRemapper {
 			final boolean saveData, final List<FileSystemReference> fsToClose) throws IOException {
 		List<CompletableFuture<List<ClassInstance>>> ret = new ArrayList<>();
 
-		Files.walkFileTree(file, new SimpleFileVisitor<Path>() {
-			@Override
-			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-				String name = file.getFileName().toString();
+		if (Files.isDirectory(file)) {
+			Files.walkFileTree(file, new SimpleFileVisitor<Path>() {
+				@Override
+				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+					String name = file.getFileName().toString();
 
-				if (name.endsWith(".jar")
-						|| name.endsWith(".zip")
-						|| name.endsWith(".class")) {
-					ret.add(CompletableFuture.supplyAsync(new Supplier<List<ClassInstance>>() {
-						@Override
-						public List<ClassInstance> get() {
+					if (name.endsWith(".class")) {
+						ret.add(CompletableFuture.supplyAsync(() -> {
 							try {
 								return readFile(file, isInput, tags, srcPath, fsToClose);
 							} catch (URISyntaxException e) {
@@ -493,13 +490,24 @@ public class TinyRemapper {
 							} catch (IOException | ZipError e) {
 								throw new RuntimeException("Error reading file "+file, e);
 							}
-						}
-					}, threadPool));
-				}
+						}, threadPool));
+					}
 
-				return FileVisitResult.CONTINUE;
-			}
-		});
+					return FileVisitResult.CONTINUE;
+				}
+			});
+		} else {
+			ret.add(CompletableFuture.supplyAsync(() -> {
+				try {
+					return readFile(file, isInput, tags, srcPath, fsToClose);
+				} catch (URISyntaxException e) {
+					throw new RuntimeException(e);
+				} catch (IOException | ZipError e) {
+					throw new RuntimeException("Error reading file "+file, e);
+				}
+			}));
+		}
+
 
 		return ret;
 	}


### PR DESCRIPTION
This PR removes some surprising behavior involving scanning JARs.

Previously, when presented with a JAR file, Tiny Remapper would open all of its nested JAR files and treat every file as an input. However, it would not re-construct the file structure. Instead, in the output it would flatten all nested JARs into the top jar, and create conflicts if the user had also added the nested JAR as an input.

This PR reverts that behavior, and makes Tiny Remapper ignore nested JARs.