### PR TITLE
Add CLI option to ignore invokedynamic types

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
@@ -26,8 +26,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.lang.model.SourceVersion;
 

--- a/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/AsmClassRemapper.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2018, Player, asie
- * Copyright (c) 2018, 2022, FabricMC
+ * Copyright (c) 2018, 2023, FabricMC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/net/fabricmc/tinyremapper/Main.java
+++ b/src/main/java/net/fabricmc/tinyremapper/Main.java
@@ -20,8 +20,11 @@ package net.fabricmc.tinyremapper;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -192,7 +195,7 @@ public class Main {
 				System.exit(1);
 			}
 
-			try (BufferedReader reader = new BufferedReader(new FileReader(forcePropagationFile))) {
+			try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(forcePropagationFile), StandardCharsets.UTF_8))) {
 				String line;
 
 				while ((line = reader.readLine()) != null) {
@@ -214,7 +217,7 @@ public class Main {
 				System.exit(1);
 			}
 
-			try (BufferedReader reader = new BufferedReader(new FileReader(knownIndyBsmFile))) {
+			try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(knownIndyBsmFile), StandardCharsets.UTF_8))) {
 				String line;
 
 				while ((line = reader.readLine()) != null) {

--- a/src/main/java/net/fabricmc/tinyremapper/Main.java
+++ b/src/main/java/net/fabricmc/tinyremapper/Main.java
@@ -21,7 +21,6 @@ package net.fabricmc.tinyremapper;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/net/fabricmc/tinyremapper/Main.java
+++ b/src/main/java/net/fabricmc/tinyremapper/Main.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2018, Player, asie
- * Copyright (c) 2016, 2021, FabricMC
+ * Copyright (c) 2016, 2023, FabricMC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/net/fabricmc/tinyremapper/TinyRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyRemapper.java
@@ -100,6 +100,11 @@ public class TinyRemapper {
 			return this;
 		}
 
+		public Builder withKnownIndyBsm(Set<String> entries) {
+			knownIndyBsm.addAll(entries);
+			return this;
+		}
+
 		public Builder propagatePrivate(boolean value) {
 			propagatePrivate = value;
 			return this;
@@ -213,7 +218,7 @@ public class TinyRemapper {
 		public TinyRemapper build() {
 			TinyRemapper remapper = new TinyRemapper(mappingProviders, ignoreFieldDesc, threadCount,
 					keepInputData,
-					forcePropagation, propagatePrivate,
+					forcePropagation, knownIndyBsm, propagatePrivate,
 					propagateBridges, propagateRecordComponents,
 					removeFrames, ignoreConflicts, resolveMissing, checkPackageAccess || fixPackageAccess, fixPackageAccess,
 					rebuildSourceFilenames, skipLocalMapping, renameInvalidLocals, invalidLvNamePattern, inferNameFromSameLvIndex,
@@ -227,6 +232,7 @@ public class TinyRemapper {
 		private boolean ignoreFieldDesc;
 		private int threadCount;
 		private final Set<String> forcePropagation = new HashSet<>();
+		private final Set<String> knownIndyBsm = new HashSet<>();
 		private boolean keepInputData = false;
 		private boolean propagatePrivate = false;
 		private LinkedMethodPropagation propagateBridges = LinkedMethodPropagation.DISABLED;
@@ -267,7 +273,7 @@ public class TinyRemapper {
 	private TinyRemapper(Collection<IMappingProvider> mappingProviders, boolean ignoreFieldDesc,
 			int threadCount,
 			boolean keepInputData,
-			Set<String> forcePropagation, boolean propagatePrivate,
+			Set<String> forcePropagation, Set<String> knownIndyBsm, boolean propagatePrivate,
 			LinkedMethodPropagation propagateBridges, LinkedMethodPropagation propagateRecordComponents,
 			boolean removeFrames,
 			boolean ignoreConflicts,
@@ -286,6 +292,7 @@ public class TinyRemapper {
 		this.keepInputData = keepInputData;
 		this.threadPool = Executors.newFixedThreadPool(this.threadCount);
 		this.forcePropagation = forcePropagation;
+		this.knownIndyBsm = knownIndyBsm;
 		this.propagatePrivate = propagatePrivate;
 		this.propagateBridges = propagateBridges;
 		this.propagateRecordComponents = propagateRecordComponents;
@@ -1311,6 +1318,7 @@ public class TinyRemapper {
 
 	private final boolean keepInputData;
 	final Set<String> forcePropagation;
+	final Set<String> knownIndyBsm;
 	final boolean propagatePrivate;
 	final LinkedMethodPropagation propagateBridges;
 	final LinkedMethodPropagation propagateRecordComponents;


### PR DESCRIPTION
I've recently ran up against #26 in a project of mine - I get so much log spam due to tiny-remapper finding groovy indy instructions that it cannot remap that it is impossible to see any actual issues in the logs. I would like some way of turning off that warning for specific indy instructions, similar to what is already done for string concatenation. This PR adds a system property, `net.fabricmc.tinyremapper.knownindybsm` (this could definitely change, I'm by no means sold on it) for providing a list of instructions that tiny-remapper can safely assume do not need to be remapped.

If you think there may be a better approach to this than a system property, please let me know, and I can see about implementing that.