### PR TITLE
Implement barebone support for Mixin's `@Desc`

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/common/data/Message.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/common/data/Message.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2018, Player, asie
- * Copyright (c) 2021, FabricMC
+ * Copyright (c) 2021, 2023, FabricMC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -21,6 +21,7 @@ package net.fabricmc.tinyremapper.extension.mixin.common.data;
 public final class Message {
 	public static final String CANNOT_RESOLVE_CLASS = "Cannot resolve class %s";
 	public static final String CONFLICT_MAPPING = "Conflict mapping detected, %s -> %s.";
+	public static final String MULTIPLE_MAPPING_CHOICES = "Multiple conflicting mapping choices found for %s, which can be remapped to %s or %s. Such issues can be resolved by using fully qualified selectors.";
 	public static final String NO_MAPPING_NON_RECURSIVE = "Cannot remap %s because it does not exists in any of the targets %s";
 	public static final String NO_MAPPING_RECURSIVE = "Cannot remap %s because it does not exists in any of the targets %s or their parents.";
 	public static final String NOT_FULLY_QUALIFIED = "%s is not fully qualified.";

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -62,7 +62,7 @@ class CommonInjectionAnnotationVisitor extends FirstPassAnnotationVisitor {
 	public void visitEnd() {
 		// The second pass is needed regardless of remap, because it may have
 		// children annotation need to remap.
-		this.accept(new CommonInjectionSecondPassAnnotationVisitor(data, delegate, remap, targets, desc));
+		this.accept(new CommonInjectionSecondPassAnnotationVisitor(data, delegate, remap, targets));
 
 		super.visitEnd();
 	}
@@ -128,16 +128,14 @@ class CommonInjectionAnnotationVisitor extends FirstPassAnnotationVisitor {
 
 		private final boolean remap;
 		private final List<String> targets;
-		private final String annotationDesc;
 
-		CommonInjectionSecondPassAnnotationVisitor(CommonData data, AnnotationVisitor delegate, boolean remap, List<String> targets, String annotationDesc) {
+		CommonInjectionSecondPassAnnotationVisitor(CommonData data, AnnotationVisitor delegate, boolean remap, List<String> targets) {
 			super(Constant.ASM_VERSION, delegate);
 
 			this.data = Objects.requireNonNull(data);
 
 			this.targets = Objects.requireNonNull(targets);
 			this.remap = remap;
-			this.annotationDesc = Objects.requireNonNull(annotationDesc);
 		}
 
 		@Override
@@ -186,16 +184,8 @@ class CommonInjectionAnnotationVisitor extends FirstPassAnnotationVisitor {
 							throw new RuntimeException("Unexpected annotation " + descriptor);
 						}
 
-						MemberType expectedDescType;
-
-						if (annotationDesc.equals(Annotation.MODIFY_CONSTANT)) {
-							expectedDescType = MemberType.FIELD;
-						} else {
-							expectedDescType = MemberType.METHOD;
-						}
-
 						AnnotationVisitor av1 = super.visitAnnotation(name, descriptor);
-						return new DescAnnotationVisitor(targets, data, av1, expectedDescType);
+						return new DescAnnotationVisitor(targets, data, av1, MemberType.METHOD);
 					}
 				};
 			} else if (name.equals(AnnotationElement.AT)) {	// @Inject

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -187,11 +187,13 @@ class CommonInjectionAnnotationVisitor extends FirstPassAnnotationVisitor {
 						}
 
 						MemberType expectedDescType;
+
 						if (annotationDesc.equals(Annotation.MODIFY_CONSTANT)) {
 							expectedDescType = MemberType.FIELD;
 						} else {
 							expectedDescType = MemberType.METHOD;
 						}
+
 						AnnotationVisitor av1 = super.visitAnnotation(name, descriptor);
 						return new DescAnnotationVisitor(targets, data, av1, expectedDescType);
 					}

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/DescAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/DescAnnotationVisitor.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2016, 2018, Player, asie
+ * Copyright (c) 2023, FabricMC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.Type;
+
+import net.fabricmc.tinyremapper.api.TrField;
+import net.fabricmc.tinyremapper.api.TrMember.MemberType;
+import net.fabricmc.tinyremapper.api.TrMethod;
+import net.fabricmc.tinyremapper.extension.mixin.common.ResolveUtility;
+import net.fabricmc.tinyremapper.extension.mixin.common.data.AnnotationElement;
+import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+import net.fabricmc.tinyremapper.extension.mixin.common.data.Constant;
+import net.fabricmc.tinyremapper.extension.mixin.common.data.Message;
+
+class DescAnnotationVisitor extends AnnotationVisitor {
+
+	private final List<String> targets;
+	private final CommonData data;
+	private final MemberType expectedType;
+
+	private List<Type> args;
+	private Type owner;
+	private Type ret;
+	private String value;
+
+	DescAnnotationVisitor(List<String> targets, CommonData data, AnnotationVisitor annotationVisitor, MemberType expectedType) {
+		super(Constant.ASM_VERSION, annotationVisitor);
+		this.targets = targets;
+		this.data = data;
+		this.expectedType = Objects.requireNonNull(expectedType);
+	}
+
+	@Override
+	public void visit(String name, Object value) {
+		if (name.equals(AnnotationElement.OWNER)) {
+			owner = Objects.requireNonNull((Type) value);
+			super.visit(name, value);
+		} else if (name.equals(AnnotationElement.RET)) {
+			ret = Objects.requireNonNull((Type) value);
+			super.visit(name, value);
+		} else if (name.equals(AnnotationElement.VALUE)) {
+			this.value = Objects.requireNonNull((String) value);
+		} else {
+			super.visit(name, value);
+		}
+	}
+
+	@Override
+	public AnnotationVisitor visitArray(String name) {
+		if (name.equals(AnnotationElement.ARGS)) {
+			return new AnnotationVisitor(Constant.ASM_VERSION, super.visitArray(name)) {
+				private final List<Type> argArray = new ArrayList<>();
+
+				@Override
+				public void visit(String name, Object value) {
+					argArray.add(Objects.requireNonNull((Type) value));
+				}
+
+				@Override
+				public void visitEnd() {
+					args = Collections.unmodifiableList(argArray);
+				}
+			};
+		} else {
+			return super.visitArray(name);
+		}
+	}
+
+	@Override
+	public void visitEnd() {
+
+		Objects.requireNonNull(value);
+
+		List<String> potentialOwners = targets;
+
+		if (owner != null) {
+			potentialOwners = Collections.singletonList(owner.getInternalName());
+		}
+
+		if (expectedType == MemberType.METHOD) {
+			String desc = "(";
+			if (args != null) {
+				for (Type arg : args) {
+					desc += arg.getDescriptor();
+				}
+			}
+
+			desc += ")";
+			if (ret != null) {
+				desc += ret.getDescriptor();
+			} else {
+				desc += "V";
+			}
+
+			// TODO We assume that we get 1:1 mappings, however it is possible (especially with multiple owners) that
+			// 1:N mappings are produced. In that case multiple @Desc annotations need to be generated.
+			// The exception is if the @Desc annot is located in an @At annotation, in which adding a @Desc
+			// is not possible as the @Desc annot is singular.
+			// HOWEVER it would still be possible to use "standard" regex target selectors.
+			// HOWEVER in doing so we would no longer be able to match both fields and methods within a single selector.
+			// In short all approaches are not ideal
+
+			String proposedName = null;
+
+			for (String owner: potentialOwners) {
+				Optional<TrMethod> resolved = data.resolver.resolveMethod(owner, value, desc, ResolveUtility.FLAG_RECURSIVE | ResolveUtility.FLAG_UNIQUE);
+				if (!resolved.isPresent()) {
+					continue;
+				}
+
+				String remapped = data.mapper.mapName(resolved.get());
+				if (proposedName == null) {
+					proposedName = remapped;
+				} else if (!proposedName.equals(remapped)) {
+					data.logger.error(String.format(Message.MULTIPLE_MAPPING_CHOICES, value + desc, owner + "." + remapped + desc, proposedName + desc));
+				}
+			}
+
+			if (proposedName != null) {
+				super.visit("value", proposedName);
+			} else {
+				super.visit("value", value);
+			}
+		} else if (expectedType == MemberType.FIELD) {
+			if (ret == null) {
+				data.logger.warn(String.format(Message.NOT_FULLY_QUALIFIED, owner + "." + value));
+				super.visit("value", value);
+				super.visitEnd();
+				return;
+			}
+
+			String proposedName = null;
+			String desc = ret.getDescriptor();
+
+			for (String owner: potentialOwners) {
+				Optional<TrField> resolved = data.resolver.resolveField(owner, value, desc, ResolveUtility.FLAG_RECURSIVE | ResolveUtility.FLAG_UNIQUE);
+				if (!resolved.isPresent()) {
+					continue;
+				}
+
+				String remapped = data.mapper.mapName(resolved.get());
+				if (proposedName == null) {
+					proposedName = remapped;
+				} else if (!proposedName.equals(remapped)) {
+					data.logger.error(String.format(Message.MULTIPLE_MAPPING_CHOICES, value + desc, owner + "." + remapped + desc, proposedName + desc));
+				}
+			}
+
+			if (proposedName != null) {
+				super.visit("value", proposedName);
+			} else {
+				super.visit("value", value);
+			}
+		}
+
+		super.visitEnd();
+	}
+}

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/DescAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/DescAnnotationVisitor.java
@@ -37,7 +37,6 @@ import net.fabricmc.tinyremapper.extension.mixin.common.data.Constant;
 import net.fabricmc.tinyremapper.extension.mixin.common.data.Message;
 
 class DescAnnotationVisitor extends AnnotationVisitor {
-
 	private final List<String> targets;
 	private final CommonData data;
 	private final MemberType expectedType;
@@ -92,9 +91,7 @@ class DescAnnotationVisitor extends AnnotationVisitor {
 
 	@Override
 	public void visitEnd() {
-
 		Objects.requireNonNull(value);
-
 		List<String> potentialOwners = targets;
 
 		if (owner != null) {
@@ -103,6 +100,7 @@ class DescAnnotationVisitor extends AnnotationVisitor {
 
 		if (expectedType == MemberType.METHOD) {
 			String desc = "(";
+
 			if (args != null) {
 				for (Type arg : args) {
 					desc += arg.getDescriptor();
@@ -110,6 +108,7 @@ class DescAnnotationVisitor extends AnnotationVisitor {
 			}
 
 			desc += ")";
+
 			if (ret != null) {
 				desc += ret.getDescriptor();
 			} else {
@@ -128,11 +127,13 @@ class DescAnnotationVisitor extends AnnotationVisitor {
 
 			for (String owner: potentialOwners) {
 				Optional<TrMethod> resolved = data.resolver.resolveMethod(owner, value, desc, ResolveUtility.FLAG_RECURSIVE | ResolveUtility.FLAG_UNIQUE);
+
 				if (!resolved.isPresent()) {
 					continue;
 				}
 
 				String remapped = data.mapper.mapName(resolved.get());
+
 				if (proposedName == null) {
 					proposedName = remapped;
 				} else if (!proposedName.equals(remapped)) {
@@ -158,11 +159,13 @@ class DescAnnotationVisitor extends AnnotationVisitor {
 
 			for (String owner: potentialOwners) {
 				Optional<TrField> resolved = data.resolver.resolveField(owner, value, desc, ResolveUtility.FLAG_RECURSIVE | ResolveUtility.FLAG_UNIQUE);
+
 				if (!resolved.isPresent()) {
 					continue;
 				}
 
 				String remapped = data.mapper.mapName(resolved.get());
+
 				if (proposedName == null) {
 					proposedName = remapped;
 				} else if (!proposedName.equals(remapped)) {


### PR DESCRIPTION
Current drawbacks:
 - No "1:N" mappings (which may be the case for multiple owner classes)
 - No support for `@Desc` within `@At` (custom injection points would make it difficult to impossible to differ between method and field and thus it requires a different philosophy. However for my purposes I don't need `@Desc` in `@At` just yet)
 
 These drawbacks would require a novel idea to get resolved and in my opinion result from the fact that `@Desc` was not meant to get remapped.
 
 I believe I have briefly mentioned regex support within explicit target selectors, which in theory would allow to condense 1:N mappings down into a single regex string but even then we would get behavioral changes. Plus I don't know how far the capabilities of regex within explicit target selectors reach.
 
 
 As such the idea of this PR is more of a "it's better than nothing", with the sour taste of there being a few edge cases that were left unattended