### PR TITLE
Update asm dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
-version = '0.8.9'
+version = '0.8.10'
 
 def ENV = System.getenv()
 version = version + (ENV.GITHUB_ACTIONS ? "" : "+local")
@@ -22,10 +22,10 @@ repositories {
 }
 
 dependencies {
-	api 'org.ow2.asm:asm:9.3'
-	api 'org.ow2.asm:asm-commons:9.3'
-	implementation 'org.ow2.asm:asm-tree:9.3'
-	implementation 'org.ow2.asm:asm-util:9.3'
+	api 'org.ow2.asm:asm:9.5'
+	api 'org.ow2.asm:asm-commons:9.5'
+	implementation 'org.ow2.asm:asm-tree:9.5'
+	implementation 'org.ow2.asm:asm-util:9.5'
 
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
 }


### PR DESCRIPTION
Allows downstream projects to use newer java versions when depending on tiny-remapper.

My company's product uses tiny-remapper as a tool, but cannot use newer versions of the java toolchain because running tiny-remapper fails as the old version of asm does not recognize newer java class file versions.