### PR TITLE
Fix random mixin members not getting remapped due to concurrency issues

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/MixinExtension.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/MixinExtension.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2018, Player, asie
- * Copyright (c) 2021, FabricMC
+ * Copyright (c) 2021, 2023, FabricMC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/HardTargetMixinClassVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/HardTargetMixinClassVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2018, Player, asie
- * Copyright (c) 2021, FabricMC
+ * Copyright (c) 2021, 2023, FabricMC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/HardTargetMixinClassVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/HardTargetMixinClassVisitor.java
@@ -19,6 +19,7 @@
 package net.fabricmc.tinyremapper.extension.mixin.hard;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -41,7 +42,7 @@ import net.fabricmc.tinyremapper.extension.mixin.hard.annotation.MixinAnnotation
 import net.fabricmc.tinyremapper.extension.mixin.hard.data.SoftInterface;
 
 public class HardTargetMixinClassVisitor extends ClassVisitor {
-	private final List<Consumer<CommonData>> tasks;
+	private final Collection<Consumer<CommonData>> tasks;
 	private MxClass _class;
 
 	// @Mixin
@@ -51,7 +52,7 @@ public class HardTargetMixinClassVisitor extends ClassVisitor {
 	// @Implements
 	private final List<SoftInterface> interfaces = new ArrayList<>();
 
-	public HardTargetMixinClassVisitor(List<Consumer<CommonData>> tasks, ClassVisitor delegate) {
+	public HardTargetMixinClassVisitor(Collection<Consumer<CommonData>> tasks, ClassVisitor delegate) {
 		super(Constant.ASM_VERSION, delegate);
 		this.tasks = Objects.requireNonNull(tasks);
 	}

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/HardTargetMixinFieldVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/HardTargetMixinFieldVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2018, Player, asie
- * Copyright (c) 2021, FabricMC
+ * Copyright (c) 2021, 2023, FabricMC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/HardTargetMixinFieldVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/HardTargetMixinFieldVisitor.java
@@ -18,6 +18,7 @@
 
 package net.fabricmc.tinyremapper.extension.mixin.hard;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -32,13 +33,13 @@ import net.fabricmc.tinyremapper.extension.mixin.common.data.MxMember;
 import net.fabricmc.tinyremapper.extension.mixin.hard.annotation.ShadowAnnotationVisitor;
 
 class HardTargetMixinFieldVisitor extends FieldVisitor {
-	private final List<Consumer<CommonData>> tasks;
+	private final Collection<Consumer<CommonData>> tasks;
 	private final MxMember field;
 
 	private final boolean remap;
 	private final List<String> targets;
 
-	HardTargetMixinFieldVisitor(List<Consumer<CommonData>> tasks, FieldVisitor delegate, MxMember field,
+	HardTargetMixinFieldVisitor(Collection<Consumer<CommonData>> tasks, FieldVisitor delegate, MxMember field,
 								boolean remap, List<String> targets) {
 		super(Constant.ASM_VERSION, delegate);
 		this.tasks = Objects.requireNonNull(tasks);

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/HardTargetMixinMethodVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/HardTargetMixinMethodVisitor.java
@@ -18,6 +18,7 @@
 
 package net.fabricmc.tinyremapper.extension.mixin.hard;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -35,13 +36,13 @@ import net.fabricmc.tinyremapper.extension.mixin.hard.annotation.OverwriteAnnota
 import net.fabricmc.tinyremapper.extension.mixin.hard.annotation.ShadowAnnotationVisitor;
 
 class HardTargetMixinMethodVisitor extends MethodVisitor {
-	private final List<Consumer<CommonData>> data;
+	private final Collection<Consumer<CommonData>> data;
 	private final MxMember method;
 
 	private final boolean remap;
 	private final List<String> targets;
 
-	HardTargetMixinMethodVisitor(List<Consumer<CommonData>> data, MethodVisitor delegate, MxMember method, boolean remap, List<String> targets) {
+	HardTargetMixinMethodVisitor(Collection<Consumer<CommonData>> data, MethodVisitor delegate, MxMember method, boolean remap, List<String> targets) {
 		super(Constant.ASM_VERSION, delegate);
 		this.data = Objects.requireNonNull(data);
 		this.method = Objects.requireNonNull(method);

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/HardTargetMixinMethodVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/HardTargetMixinMethodVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2018, Player, asie
- * Copyright (c) 2021, FabricMC
+ * Copyright (c) 2021, 2023, FabricMC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/AccessorAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/AccessorAnnotationVisitor.java
@@ -42,14 +42,14 @@ import net.fabricmc.tinyremapper.extension.mixin.hard.util.IConvertibleString;
  * do not lower the first character of the remaining part.
  */
 public class AccessorAnnotationVisitor extends AnnotationVisitor {
-	private final List<Consumer<CommonData>> tasks;
+	private final Collection<Consumer<CommonData>> tasks;
 	private final MxMember method;
 	private final List<String> targets;
 
 	private boolean remap;
 	private boolean isSoftTarget;
 
-	public AccessorAnnotationVisitor(List<Consumer<CommonData>> tasks, AnnotationVisitor delegate, MxMember method, boolean remap, List<String> targets) {
+	public AccessorAnnotationVisitor(Collection<Consumer<CommonData>> tasks, AnnotationVisitor delegate, MxMember method, boolean remap, List<String> targets) {
 		super(Constant.ASM_VERSION, delegate);
 
 		this.tasks = Objects.requireNonNull(tasks);

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/AccessorAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/AccessorAnnotationVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2018, Player, asie
- * Copyright (c) 2021, FabricMC
+ * Copyright (c) 2021, 2023, FabricMC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/ImplementsAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/ImplementsAnnotationVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2018, Player, asie
- * Copyright (c) 2021, FabricMC
+ * Copyright (c) 2021, 2023, FabricMC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/ImplementsAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/ImplementsAnnotationVisitor.java
@@ -81,7 +81,7 @@ public class ImplementsAnnotationVisitor extends AnnotationVisitor {
 		}
 	}
 
-	public static void visitMethod(List<Consumer<CommonData>> tasks, MxMember method, List<SoftInterface> interfaces) {
+	public static void visitMethod(Collection<Consumer<CommonData>> tasks, MxMember method, List<SoftInterface> interfaces) {
 		tasks.add(data -> new SoftImplementsMappable(data, method, interfaces).result());
 	}
 

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/InvokerAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/InvokerAnnotationVisitor.java
@@ -40,14 +40,14 @@ import net.fabricmc.tinyremapper.extension.mixin.hard.util.IConvertibleString;
  * do not lower the first character of the remaining part.
  */
 public class InvokerAnnotationVisitor extends AnnotationVisitor {
-	private final List<Consumer<CommonData>> tasks;
+	private final Collection<Consumer<CommonData>> tasks;
 	private final MxMember method;
 	private final List<String> targets;
 
 	private boolean remap;
 	private boolean isSoftTarget;
 
-	public InvokerAnnotationVisitor(List<Consumer<CommonData>> tasks, AnnotationVisitor delegate, MxMember method, boolean remap, List<String> targets) {
+	public InvokerAnnotationVisitor(Collection<Consumer<CommonData>> tasks, AnnotationVisitor delegate, MxMember method, boolean remap, List<String> targets) {
 		super(Constant.ASM_VERSION, delegate);
 
 		this.tasks = Objects.requireNonNull(tasks);

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/InvokerAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/InvokerAnnotationVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2018, Player, asie
- * Copyright (c) 2021, FabricMC
+ * Copyright (c) 2021, 2023, FabricMC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/OverwriteAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/OverwriteAnnotationVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2018, Player, asie
- * Copyright (c) 2021, FabricMC
+ * Copyright (c) 2021, 2023, FabricMC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/OverwriteAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/OverwriteAnnotationVisitor.java
@@ -38,13 +38,13 @@ import net.fabricmc.tinyremapper.extension.mixin.hard.util.IdentityString;
  * an error message will show up and the behaviour is undefined.
  */
 public class OverwriteAnnotationVisitor extends AnnotationVisitor {
-	private final List<Consumer<CommonData>> tasks;
+	private final Collection<Consumer<CommonData>> tasks;
 	private final MxMember method;
 	private final List<String> targets;
 
 	private boolean remap;
 
-	public OverwriteAnnotationVisitor(List<Consumer<CommonData>> tasks, AnnotationVisitor delegate, MxMember method, boolean remap, List<String> targets) {
+	public OverwriteAnnotationVisitor(Collection<Consumer<CommonData>> tasks, AnnotationVisitor delegate, MxMember method, boolean remap, List<String> targets) {
 		super(Constant.ASM_VERSION, delegate);
 
 		this.tasks = Objects.requireNonNull(tasks);

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/ShadowAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/ShadowAnnotationVisitor.java
@@ -40,14 +40,14 @@ import net.fabricmc.tinyremapper.extension.mixin.hard.util.PrefixString;
  * If a prefix is detected, will only attempt to match the prefix-stripped name.
  */
 public class ShadowAnnotationVisitor extends AnnotationVisitor {
-	private final List<Consumer<CommonData>> tasks;
+	private final Collection<Consumer<CommonData>> tasks;
 	private final MxMember member;
 	private final List<String> targets;
 
 	private boolean remap;
 	private String prefix;
 
-	public ShadowAnnotationVisitor(List<Consumer<CommonData>> tasks, AnnotationVisitor delegate, MxMember member, boolean remap, List<String> targets) {
+	public ShadowAnnotationVisitor(Collection<Consumer<CommonData>> tasks, AnnotationVisitor delegate, MxMember member, boolean remap, List<String> targets) {
 		super(Constant.ASM_VERSION, delegate);
 		this.tasks = Objects.requireNonNull(tasks);
 		this.member = Objects.requireNonNull(member);

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/ShadowAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/hard/annotation/ShadowAnnotationVisitor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2018, Player, asie
- * Copyright (c) 2021, FabricMC
+ * Copyright (c) 2021, 2023, FabricMC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by


### PR DESCRIPTION
When remapping a jar with many mixins (sponge jar) I discovered that some members were not remapped properly. Which members were not remapped was fully random and changed each time I re execute the task.

After some debugging I found that multiple threads are writing to the `tasks` list in `MixinExtension` but this list is not thread-safe. I tried replacing it with a thread-safe collection and it fixed my problem. Here is the fix.