### PR TITLE
Allow enabling extensions from the classpath via CLI args

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/Main.java
+++ b/src/main/java/net/fabricmc/tinyremapper/Main.java
@@ -287,7 +287,7 @@ public class Main {
 		TinyRemapper.CLIExtensionProvider provider = providerMap.get(extName);
 
 		if (provider == null) {
-			System.out.println("No such extension: " + extName);
+			System.err.println("No such extension: " + extName);
 			System.exit(1);
 		}
 

--- a/src/main/java/net/fabricmc/tinyremapper/Main.java
+++ b/src/main/java/net/fabricmc/tinyremapper/Main.java
@@ -150,28 +150,26 @@ public class Main {
 				case "mixin":
 					enableMixin = true;
 					break;
-				default:
-					String argKeyLower = argKey.toLowerCase(Locale.ROOT);
-					TinyRemapper.CLIExtensionProvider provider = providerMap.get(argKeyLower);
+				case "ext":
+				case "extension":
+					String extName = arg.substring(valueSepPos + 1);
+					TinyRemapper.CLIExtensionProvider provider = providerMap.get(extName);
 
 					if (provider == null) {
-						System.out.println("invalid argument: "+arg+".");
+						System.out.println("No such extension: " + extName);
 						System.exit(1);
 					}
 
-					String value;
+					TinyRemapper.Extension extension = provider.provideExtension();
 
-					if (provider.acceptsValue()) {
-						value = arg.substring(valueSepPos + 1);
-					} else {
-						value = null;
+					if (extension != null) {
+						providedExtensions.add(extension);
 					}
 
-					TinyRemapper.Extension provided = provider.provideExtension(value);
-
-					if (provided != null) {
-						providedExtensions.add(provided);
-					}
+					break;
+				default:
+					System.out.println("invalid argument: "+arg+".");
+					System.exit(1);
 				}
 			} else {
 				args.add(arg);

--- a/src/main/java/net/fabricmc/tinyremapper/TinyRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyRemapper.java
@@ -259,12 +259,10 @@ public class TinyRemapper {
 	}
 
 	public interface CLIExtensionProvider {
-		boolean acceptsValue();
-
 		String name();
 
-		// nullable return and value
-		Extension provideExtension(String value);
+		// nullable return
+		Extension provideExtension();
 	}
 
 	public interface AnalyzeVisitorProvider {

--- a/src/main/java/net/fabricmc/tinyremapper/TinyRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyRemapper.java
@@ -258,6 +258,15 @@ public class TinyRemapper {
 		void attach(TinyRemapper.Builder builder);
 	}
 
+	public interface CLIExtensionProvider {
+		boolean acceptsValue();
+
+		String name();
+
+		// nullable return and value
+		Extension provideExtension(String value);
+	}
+
 	public interface AnalyzeVisitorProvider {
 		/**
 		 * @deprecated use {@link #insertAnalyzeVisitor(boolean, int, String, ClassVisitor, InputTag[])} instead

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/MixinExtension.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/MixinExtension.java
@@ -57,6 +57,18 @@ public class MixinExtension implements TinyRemapper.Extension {
 	private final Set<AnnotationTarget> targets;
 	private final /* @Nullable */ Predicate<InputTag> inputTagFilter;
 
+	public static final class CLIProvider implements TinyRemapper.CLIExtensionProvider {
+		@Override
+		public String name() {
+			return "mixin";
+		}
+
+		@Override
+		public TinyRemapper.Extension provideExtension() {
+			return new MixinExtension();
+		}
+	}
+
 	public enum AnnotationTarget {
 		/**
 		 * The string literal in mixin annotation. E.g. Mixin, Invoker, Accessor, Inject,

--- a/src/main/resources/META-INF/services/net.fabricmc.tinyremapper.TinyRemapper$CLIExtensionProvider
+++ b/src/main/resources/META-INF/services/net.fabricmc.tinyremapper.TinyRemapper$CLIExtensionProvider
@@ -1,0 +1,1 @@
+net.fabricmc.tinyremapper.extension.mixin.MixinExtension$CLIProvider


### PR DESCRIPTION
This could be used to add Kotlin remapping to the CLI without adding it directly to TR.