### PR TITLE
Fix Desc.args being stripped in the remapping process

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/DescAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/DescAnnotationVisitor.java
@@ -77,11 +77,13 @@ class DescAnnotationVisitor extends AnnotationVisitor {
 				@Override
 				public void visit(String name, Object value) {
 					argArray.add(Objects.requireNonNull((Type) value));
+					super.visit(name, value);
 				}
 
 				@Override
 				public void visitEnd() {
 					args = Collections.unmodifiableList(argArray);
+					super.visitEnd();
 				}
 			};
 		} else {


### PR DESCRIPTION
Fixes #135

--

In hindsight I'm a little bit surprised that this didn't end up producing mangled bytecode since visitArray would be called while visitEnd would never be called. However, the result was invalid either way, so this change resolves that issue at the very least, though the other (known) shortfalls of how `@Desc` is being remapped in tiny-remapper remain unaddressed. Though given that this rather serious bug remained unnoticed for a bit longer than a year is a good indicator that investing all too much resources in more nuanced edge-cases is a bit … overreacting.