### PR TITLE
Fix wildcard targets

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/data/MemberInfo.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/data/MemberInfo.java
@@ -129,8 +129,26 @@ public final class MemberInfo {
 	@Override
 	public String toString() {
 		String owner = getOwner().isEmpty() ? "" : StringUtility.classNameToDesc(getOwner());
-		String desc = getDesc().isEmpty() ? "" : (Objects.equals(getType(), MemberType.FIELD) ? ":" : "") + getDesc();
 
-		return owner + name + quantifier + desc;
+		return owner + name + quantifier + formattedDesc();
+	}
+
+	private String formattedDesc() {
+		final String desc = getDesc();
+
+		if (desc.isEmpty()) {
+			return "";
+		}
+
+		if (Objects.equals(getType(), MemberType.FIELD)) {
+			return ":" + desc;
+		}
+
+		// Wildcards match regardless of descriptor
+		if (getQuantifier().equals("*")) {
+			return "";
+		}
+
+		return desc;
 	}
 }

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/soft/data/MemberInfoTest.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/soft/data/MemberInfoTest.java
@@ -98,5 +98,23 @@ class MemberInfoTest {
 		assertEquals(info.getQuantifier(), "");
 		assertEquals(info.getDesc(), "([C)Ljava/lang/String;");
 		assertEquals(info.toString(), "([C)Ljava/lang/String;");
+
+		info = MemberInfo.parse("<init>*");
+		assertNotNull(info);
+		assertNull(info.getType());
+		assertEquals(info.getOwner(), "");
+		assertEquals(info.getName(), "<init>");
+		assertEquals(info.getQuantifier(), "*");
+		assertEquals(info.getDesc(), "");
+		assertEquals(info.toString(), "<init>*");
+
+		info = new MemberInfo("", "<init>", "*", "()V");
+		assertNotNull(info);
+		assertEquals(info.getType(), MemberType.METHOD);
+		assertEquals(info.getOwner(), "");
+		assertEquals(info.getName(), "<init>");
+		assertEquals(info.getQuantifier(), "*");
+		assertEquals(info.getDesc(), "()V");
+		assertEquals(info.toString(), "<init>*");
 	}
 }


### PR DESCRIPTION
Fixes #137

Wildcard targets should not specify a desc.

When remapping the name of the first matching method will be used.