### PR TITLE
chore: upgrade asm to 9.7 to support java 23

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,10 @@ repositories {
 }
 
 dependencies {
-	api 'org.ow2.asm:asm:9.7'
-	api 'org.ow2.asm:asm-commons:9.7'
-	implementation 'org.ow2.asm:asm-tree:9.7'
-	implementation 'org.ow2.asm:asm-util:9.7'
+	api 'org.ow2.asm:asm:9.7.1'
+	api 'org.ow2.asm:asm-commons:9.7.1'
+	implementation 'org.ow2.asm:asm-tree:9.7.1'
+	implementation 'org.ow2.asm:asm-util:9.7.1'
 	implementation "net.fabricmc:mapping-io:0.5.0"
 
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'

--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,10 @@ repositories {
 }
 
 dependencies {
-	api 'org.ow2.asm:asm:9.6'
-	api 'org.ow2.asm:asm-commons:9.6'
-	implementation 'org.ow2.asm:asm-tree:9.6'
-	implementation 'org.ow2.asm:asm-util:9.6'
+	api 'org.ow2.asm:asm:9.7'
+	api 'org.ow2.asm:asm-commons:9.7'
+	implementation 'org.ow2.asm:asm-tree:9.7'
+	implementation 'org.ow2.asm:asm-util:9.7'
 	implementation "net.fabricmc:mapping-io:0.5.0"
 
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'


### PR DESCRIPTION
Hi,
I wanted to update ASM to 9.7 because otherwise paperweight is failing (its using TR).
I am not sure how to properly test this change as I am not that familiar with TR so I just ran the unit / integration tests.


```
Caused by: java.lang.RuntimeException: error analyzing X/WorldRegion.class from X
	at net.fabricmc.tinyremapper.TinyRemapper.analyze(TinyRemapper.java:604)
	at net.fabricmc.tinyremapper.TinyRemapper.access$400(TinyRemapper.java:71)
	at net.fabricmc.tinyremapper.TinyRemapper$2.visitFile(TinyRemapper.java:553)
	at net.fabricmc.tinyremapper.TinyRemapper$2.visitFile(TinyRemapper.java:549)
	at java.base/java.nio.file.Files.walkFileTree(Files.java:2810)
	at java.base/java.nio.file.Files.walkFileTree(Files.java:2881)
	at net.fabricmc.tinyremapper.TinyRemapper.readFile(TinyRemapper.java:549)
	at net.fabricmc.tinyremapper.TinyRemapper.access$200(TinyRemapper.java:71)
	at net.fabricmc.tinyremapper.TinyRemapper$1$1.get(TinyRemapper.java:521)
	at net.fabricmc.tinyremapper.TinyRemapper$1$1.get(TinyRemapper.java:517)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1812)
	... 3 more
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 67
	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:200)
	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:180)
	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:166)
	at net.fabricmc.tinyremapper.TinyRemapper.analyze(TinyRemapper.java:602)
	... 13 more
```