### PR TITLE
fix: try resolving conflicts by using `getNewMappedName`

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/TinyRemapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyRemapper.java
@@ -894,7 +894,8 @@ public class TinyRemapper {
 					Map<String, String> mappings = member.type == TrMember.MemberType.METHOD ? methodMap : fieldMap;
 					String mappingName = mappings.get(member.cls.getName()+"/"+member.getId());
 
-					if (mappingName == null) { // no direct mapping match, try parents
+					// Attempt to find a mapping name for the member
+					if (mappingName == null) {
 						Queue<ClassInstance> queue = new ArrayDeque<>(member.cls.parents);
 						ClassInstance cls;
 
@@ -903,6 +904,14 @@ public class TinyRemapper {
 							if (mappingName != null) break;
 
 							queue.addAll(cls.parents);
+						}
+					}
+
+					if (mappingName == null) {
+						String fullName = member.cls.getName() + "/" + member.getNewMappedName();
+
+						if (entry.getValue().contains(fullName)) {
+							mappingName = fullName;
 						}
 					}
 


### PR DESCRIPTION
Resolves https://github.com/architectury/architectury-loom/issues/283

We’re seeing this conflict error:

```
Mapping source name conflicts detected:
  kn METHOD c ((Lkp;)Z) -> [kn/method_57832, kn/method_57826]
    fixable: replaced with method_57832
  kl METHOD c ((Lkp;)Z) -> [kl/method_57826, kn/method_57832]
  km METHOD c ((Lkp;)Z) -> [kn/method_57832, km/method_57826]
    fixable: replaced with method_57826
  kn$a$a METHOD c ((Lkp;)Z) -> [kn/method_57832, kn$a$a/method_57826]
    fixable: replaced with method_57832
```

The only unfixable conflict is:

```
kl METHOD c ((Lkp;)Z) -> [kl/method_57826, kn/method_57832]
```

It should prefer `kl/method_57826`, but currently doesn't.

This PR adds an alternative conflict resolution strategy: if all existing checks fail (e.g. parent-based), we fall back to resolving by `member.cls.getName() + "/" + member.getNewMappedName()`.

This change is non-breaking and only runs as a last resort. It fixes the above issue without altering existing behaviour.