### PR TITLE
Re-enable inferring missing mappings from the source namespace

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
+++ b/src/main/java/net/fabricmc/tinyremapper/TinyUtils.java
@@ -98,7 +98,7 @@ public final class TinyUtils {
 						new FlatAsRegularMappingVisitor(new MappingAdapter(out)),
 						toNs),
 				fromNs,
-				true);
+				false); // infers mappings for non-obfuscated names from the src ns
 	}
 
 	private static final class MappingAdapter implements FlatMappingVisitor {


### PR DESCRIPTION
We should keep inferring those names like in older TR versions. Without this mappings that rely on implicitly defined no-op mappings break when TR operates on a different source namespace from the mappings. Typically this involves deobfuscated class names that then cause their members to not get remapped.

Dropping missing mappings instead of inferring from source might show issues more proactively, but that'd require more effort on the API user and acts more surprisingly in typical use cases like below.

Fixes https://github.com/FabricMC/fabric-loader/issues/1067
babric provides mappings for MC b1.7.3, a version that has a deobfuscated MC class name with obfuscated member names. The babric mappings don't have the noop class entry MC -> MC, the mapping file's source NS is `intermediary` and TR remaps `clientOfficial` to `intermediary`. Without this PR the members of the MC class retain their original obfuscated names because the mapping adapter drops all of then during the source NS adjustment. 