### PR TITLE
Fix wildcard remapping regression

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -191,7 +191,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 			}
 
 			return collection.stream().findFirst()
-					.map(pair -> new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), pair.first(), info.getQuantifier(), pair.second()))
+					.map(pair -> new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), pair.first(), info.getQuantifier(), info.getDesc().isEmpty() ? "" : pair.second()))
 					.orElse(info);
 		}
 	}

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/data/MemberInfo.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/data/MemberInfo.java
@@ -144,12 +144,6 @@ public final class MemberInfo {
 			return ":" + desc;
 		}
 
-		// Wildcards with a name match regardless of descriptor (e.g. `<init>*`)
-		// But wildcards without a name use the descriptor for matching (e.g. `*()Ljava/lang/String;`)
-		if (getQuantifier().equals("*") && !getName().isEmpty()) {
-			return "";
-		}
-
 		return desc;
 	}
 }


### PR DESCRIPTION
The test passed when it should not have because it was targeting the wrong class.

regression introduced in #149 
related: https://github.com/FabricMC/tiny-remapper/issues/137#issuecomment-3638391881
possibly related: #148