### PR TITLE
Mixin method remap: fix desc being dropped & support wildcards

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/ClassInstance.java
+++ b/src/main/java/net/fabricmc/tinyremapper/ClassInstance.java
@@ -28,6 +28,7 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -907,7 +908,7 @@ public final class ClassInstance implements TrClass {
 	final Path srcPath;
 	byte[] data;
 	private ClassInstance mrjOrigin;
-	private final Map<String, MemberInstance> members = new HashMap<>(); // methods and fields are distinct due to their different desc separators
+	private final Map<String, MemberInstance> members = new LinkedHashMap<>(); // methods and fields are distinct due to their different desc separators
 	private final ConcurrentMap<String, MemberInstance> resolvedMembers = new ConcurrentHashMap<>();
 	final Set<ClassInstance> parents = new HashSet<>();
 	final Set<ClassInstance> children = new HashSet<>();

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/common/data/Message.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/common/data/Message.java
@@ -26,4 +26,6 @@ public final class Message {
 	public static final String NO_MAPPING_RECURSIVE = "Cannot remap %s because it does not exist in any of the targets %s or their parents.";
 	public static final String NOT_FULLY_QUALIFIED = "%s is not fully qualified.";
 	public static final String MISSING_INJECT = "Unable to fully remap %s, the method %s%s could not be targeted without conflicts";
+	public static final String UNABLE_TO_PARSE_QUANTIFIER = "Unable to parse quantifier %s, remap behaviour may be incorrect";
+	public static final String UNSUPPORTED_QUANTIFIER_MIN = "Quantifier min was provided, but due to conflicts %s after remap had to use descriptor";
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/common/data/Message.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/common/data/Message.java
@@ -25,4 +25,5 @@ public final class Message {
 	public static final String NO_MAPPING_NON_RECURSIVE = "Cannot remap %s because it does not exist in any of the targets %s";
 	public static final String NO_MAPPING_RECURSIVE = "Cannot remap %s because it does not exist in any of the targets %s or their parents.";
 	public static final String NOT_FULLY_QUALIFIED = "%s is not fully qualified.";
+	public static final String MISSING_INJECT = "Unable to fully remap %s, the method %s%s could not be targeted without conflicts";
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -108,8 +108,8 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 						throw new RuntimeException("InjectMethodMappable should never resolve to zero entries");
 					}
 
-					for (MemberInfo memberInfos : resolved) {
-						super.visit(name, memberInfos.toString());
+					for (MemberInfo remappedInfo : resolved) {
+						super.visit(name, remappedInfo.toString());
 					}
 				}
 			};

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -104,6 +104,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 					}
 
 					List<MemberInfo> resolved = new InjectMethodMappable(data, info, targets).result();
+
 					if (resolved.isEmpty()) {
 						throw new RuntimeException("InjectMethodMappable should never resolve to zero entries");
 					}
@@ -183,6 +184,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 			desc = desc.isEmpty() ? null : desc;
 
 			Collection<TrMethod> col = owner.resolveMethods(name, desc, false, null, null);
+
 			if (col instanceof List) {
 				return (List<TrMethod>) col;
 			} else {
@@ -193,6 +195,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 		@Override
 		public List<MemberInfo> result() {
 			String mappedOwner = info.getOwner();
+
 			if (!mappedOwner.isEmpty()) {
 				mappedOwner = data.mapper.asTrRemapper().map(mappedOwner);
 			}
@@ -205,6 +208,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 				// Simple case when we can't find the specific method by name
 
 				String desc = info.getDesc();
+
 				if (!desc.isEmpty()) {
 					desc = data.mapper.asTrRemapper().mapDesc(desc);
 				}
@@ -221,6 +225,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 				List<TrMethod> methods = resolvePartials(target, info.getName(), info.getDesc());
 
 				int matchedCount = Math.min(methods.size(), methodsPerTarget);
+
 				for (int i = 0; i < matchedCount; i++) {
 					TrMember method = methods.get(i);
 
@@ -255,12 +260,15 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 					for (String mappedDesc : mappedDescriptors) {
 						if (canInject(mappedName, mappedDesc, fullMethodToTarget)) {
 							String quantifier = info.getQuantifier();
+
 							if (!explicitDesc) {
 								if (quantifierMin > 0) {
 									data.getLogger().error(Message.UNSUPPORTED_QUANTIFIER_MIN, info.toString());
 								}
+
 								quantifier = "";
 							}
+
 							list.add(new MemberInfo(mappedOwner, mappedName, quantifier, mappedDesc));
 						} else {
 							data.getLogger().error(Message.MISSING_INJECT, info.toString(), mappedName, mappedDesc);
@@ -286,6 +294,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 
 				for (TrMethod method : target.getMethods()) {
 					String otherName = data.mapper.mapName(method);
+
 					if (!otherName.equals(mappedName)) {
 						continue;
 					}
@@ -294,6 +303,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 
 					Pair<String, String> pair = Pair.of(otherName, otherDesc);
 					Set<TrClass> validClasses = fullMethodToTarget.get(pair);
+
 					if (validClasses == null || !validClasses.contains(target)) {
 						return false;
 					}
@@ -302,6 +312,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 					// e.g. If targeting method foo in [foo, bar -> baz, baz], we want to disambiguate the baz even though we would be
 					// targeting the correct method due to the max limit
 					toCheck -= 1;
+
 					if (toCheck <= 0 && methodsPerTarget > 1) {
 						break;
 					}
@@ -314,12 +325,14 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 		private boolean canInject(String mappedName, String mappedDesc, Map<Pair<String, String>, Set<TrClass>> fullMethodToTarget) {
 			Pair<String, String> pair = Pair.of(mappedName, mappedDesc);
 			Set<TrClass> validClasses = fullMethodToTarget.get(pair);
+
 			if (validClasses == null || validClasses.isEmpty()) {
 				return false;
 			}
 
 			for (TrClass target : targets) {
 				TrMethod method = target.getMethod(mappedName, mappedDesc);
+
 				if (method != null && !validClasses.contains(target)) {
 					return false;
 				}
@@ -337,18 +350,22 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 		if (quantifier == null || quantifier.isEmpty()) {
 			return Pair.of(0, 1);
 		}
+
 		if (quantifier.equals("*")) {
 			return Pair.of(0, Integer.MAX_VALUE);
 		}
+
 		if (quantifier.equals("+")) {
 			return Pair.of(1, Integer.MAX_VALUE);
 		}
+
 		if (!quantifier.startsWith("{") || !quantifier.endsWith("}") || quantifier.length() < 3) {
 			data.getLogger().error(Message.UNABLE_TO_PARSE_QUANTIFIER, quantifier);
 			return Pair.of(0, 0);
 		}
 
 		String inner = quantifier.substring(1, quantifier.length() - 1).trim();
+
 		if (inner.isEmpty()) {
 			data.getLogger().error(Message.UNABLE_TO_PARSE_QUANTIFIER, quantifier);
 			return Pair.of(0, 0);
@@ -358,6 +375,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 		String strMax = inner;
 
 		int comma = inner.indexOf(',');
+
 		if (comma > -1) {
 			strMin = inner.substring(0, comma).trim();
 			strMax = inner.substring(comma + 1).trim();
@@ -371,9 +389,5 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 			data.getLogger().error(Message.UNABLE_TO_PARSE_QUANTIFIER, quantifier);
 			return Pair.of(0, 0);
 		}
-
 	}
-
-
-
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -196,6 +196,19 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 
 		@Override
 		public MemberInfo[] result() {
+			if (targets.isEmpty() || info.getName().isEmpty()) {
+				// Simple case when we can't find the specific method by name
+
+				String desc = info.getDesc();
+				if (!desc.isEmpty()) {
+					desc = data.mapper.asTrRemapper().mapDesc(desc);
+				}
+
+				return new MemberInfo[] {
+					new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), info.getName(), info.getQuantifier(), desc)
+				};
+			}
+
 			if (info.getQuantifier().equals("*")) {
 				return this.wildcardResult();
 			} else {
@@ -204,17 +217,6 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 		}
 
 		private MemberInfo[] wildcardResult() {
-			// Special case to remap the desc of wildcards without a name, such as `*()Lcom/example/ClassName;`
-			if (info.getName().isEmpty() && !info.getDesc().isEmpty()) {
-				return new MemberInfo[] {
-					new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), info.getName(), "*", data.mapper.asTrRemapper().mapDesc(info.getDesc()))
-				};
-			}
-
-			if (targets.isEmpty() || info.getName().isEmpty()) {
-				return new MemberInfo[] { info };
-			}
-
 			List<Pair<String, String>> collection = targets.stream()
 			   .flatMap(target -> resolvePartials(target, info.getName(), info.getDesc()).stream())
 			   .map(m -> Pair.of(data.mapper.mapName(m), data.mapper.mapDesc(m)))
@@ -276,10 +278,6 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 		}
 
 		private MemberInfo singleResult() {
-			if (targets.isEmpty() || info.getName().isEmpty()) {
-				return info;
-			}
-
 			List<Pair<String, String>> collection = targets.stream()
 			   .map(target -> resolvePartial(target, info.getName(), info.getDesc()))
 			   .filter(Optional::isPresent)

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -288,10 +288,10 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 						continue;
 					}
 
-					toCheck -= 1;
 					if (toCheck <= 0) {
 						break;
 					}
+					toCheck -= 1;
 
 					String otherDesc = data.mapper.mapDesc(method);
 					missingDescriptors.remove(otherDesc);

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -288,19 +288,25 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 						continue;
 					}
 
-					if (toCheck <= 0) {
+					// We only break if methodsPerTarget > 1 in order to disambiguate even when unnecessary due to implicit limit of 1
+					// e.g. If targeting method foo in [foo, bar -> baz, baz], we want to disambiguate the baz even though we would be
+					// targeting the correct method due to the max limit
+					if (toCheck <= 0 && methodsPerTarget > 1) {
 						break;
 					}
-					toCheck -= 1;
 
 					String otherDesc = data.mapper.mapDesc(method);
-					missingDescriptors.remove(otherDesc);
+					if (toCheck > 0) {
+						missingDescriptors.remove(otherDesc);
+					}
 
 					Pair<String, String> pair = Pair.of(otherName, otherDesc);
 					Set<TrClass> validClasses = fullMethodToTarget.get(pair);
 					if (validClasses == null || !validClasses.contains(target)) {
 						return false;
 					}
+
+					toCheck -= 1;
 				}
 
 				// This check is needed because we might be mapping a -> b,

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -21,6 +21,7 @@ package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +41,6 @@ import net.fabricmc.tinyremapper.api.TrMember;
 import net.fabricmc.tinyremapper.api.TrMember.MemberType;
 import net.fabricmc.tinyremapper.api.TrMethod;
 import net.fabricmc.tinyremapper.extension.mixin.common.IMappable;
-import net.fabricmc.tinyremapper.extension.mixin.common.ResolveUtility;
 import net.fabricmc.tinyremapper.extension.mixin.common.data.Annotation;
 import net.fabricmc.tinyremapper.extension.mixin.common.data.AnnotationElement;
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
@@ -176,27 +176,30 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 			}
 		}
 
-		private Optional<TrMember> resolvePartial(TrClass owner, String name, String desc) {
+		private List<TrMethod> resolvePartials(TrClass owner, String name, String desc) {
 			Objects.requireNonNull(owner);
 
 			name = name.isEmpty() ? null : name;
 			desc = desc.isEmpty() ? null : desc;
 
-			return data.resolver.resolveMethod(owner, name, desc, ResolveUtility.FLAG_FIRST).map(m -> m);
-		}
-
-		private Collection<TrMethod> resolvePartials(TrClass owner, String name, String desc) {
-			Objects.requireNonNull(owner);
-
-			name = name.isEmpty() ? null : name;
-			desc = desc.isEmpty() ? null : desc;
-
-			return owner.resolveMethods(name, desc, false, null, null);
+			Collection<TrMethod> col = owner.resolveMethods(name, desc, false, null, null);
+			if (col instanceof List) {
+				return (List<TrMethod>) col;
+			} else {
+				return new ArrayList<>(col);
+			}
 		}
 
 		@Override
 		public List<MemberInfo> result() {
-			if (targets.isEmpty() || info.getName().isEmpty()) {
+			String mappedOwner = info.getOwner();
+			if (!mappedOwner.isEmpty()) {
+				mappedOwner = data.mapper.asTrRemapper().map(mappedOwner);
+			}
+
+			int methodsPerTarget = quantifierStringToMax(info.getQuantifier());
+
+			if (targets.isEmpty() || info.getName().isEmpty() || methodsPerTarget <= 0) {
 				// Simple case when we can't find the specific method by name
 
 				String desc = info.getDesc();
@@ -204,118 +207,143 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 					desc = data.mapper.asTrRemapper().mapDesc(desc);
 				}
 
-				return Collections.singletonList(new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), info.getName(), info.getQuantifier(), desc));
+				return Collections.singletonList(new MemberInfo(mappedOwner, info.getName(), info.getQuantifier(), desc));
 			}
 
-			if (info.getQuantifier().equals("*")) {
-				return this.wildcardResult();
-			} else {
-				return Collections.singletonList(singleResult());
+			// Step 1. Collect all methods we want to target
+
+			Map<Pair<String, String>, Set<TrClass>> fullMethodToTarget = new HashMap<>();
+			SortedMap<String, SortedSet<String>> namesToDesc = new TreeMap<>();
+
+			for (TrClass target : targets) {
+				List<TrMethod> methods = resolvePartials(target, info.getName(), info.getDesc());
+
+				int matchedCount = Math.min(methods.size(), methodsPerTarget);
+				for (int i = 0; i < matchedCount; i++) {
+					TrMember method = methods.get(i);
+
+					String mappedName = data.mapper.mapName(method);
+					String mappedDesc = data.mapper.mapDesc(method);
+
+					fullMethodToTarget.computeIfAbsent(Pair.of(mappedName, mappedDesc), k -> new HashSet<>()).add(target);
+					namesToDesc.computeIfAbsent(mappedName, k -> new TreeSet<>()).add(mappedDesc);
+				}
 			}
-		}
 
-		private List<MemberInfo> wildcardResult() {
-			List<Pair<String, String>> collection = targets.stream()
-			   .flatMap(target -> resolvePartials(target, info.getName(), info.getDesc()).stream())
-			   .map(m -> Pair.of(data.mapper.mapName(m), data.mapper.mapDesc(m)))
-			   .distinct()
-			   .collect(Collectors.toList());
-
-			if (collection.isEmpty()) {
-				data.getLogger().warn(Message.NO_MAPPING_NON_RECURSIVE, info.getName(), targets);
+			if (fullMethodToTarget.isEmpty()) {
+				data.getLogger().warn(Message.NO_MAPPING_NON_RECURSIVE, info.toString(), targets);
 				return Collections.singletonList(info);
 			}
 
-			SortedMap<String, SortedSet<String>> descriptorsForName = new TreeMap<>();
-			for (Pair<String, String> pair : collection) {
-				descriptorsForName.computeIfAbsent(pair.first(), k -> new TreeSet<>()).add(pair.second());
-			}
+			// Step 2. Try adding methods
+			// We need to avoid injecting into methods which weren't injected into in the source namespace
+			// The canInject() functions check to make sure we aren't targeting something unwanted
 
-			List<MemberInfo> finalMembers = new ArrayList<>();
+			List<MemberInfo> list = new ArrayList<>();
 
-			if (info.getDesc().isEmpty()) {
-				// If the descriptor was omitted in the input, we want to omit the descriptor in the output as well
-				// However, we can only do this if all the methods in the source namespace
-				// are exactly matched in the target namespace
+			boolean wantDesc = !info.getDesc().isEmpty();
 
-				for (Map.Entry<String, SortedSet<String>> entry : descriptorsForName.entrySet()) {
-					String mappedName = entry.getKey();
-					Set<String> mappedDescriptors = entry.getValue();
+			for (Map.Entry<String, SortedSet<String>> entry : namesToDesc.entrySet()) {
+				String mappedName = entry.getKey();
+				SortedSet<String> mappedDescriptors = entry.getValue();
 
-					Set<String> allDescriptorsInTargets = new HashSet<>();
-
-					for (TrClass target : targets) {
-						for (TrMethod method : target.getMethods()) {
-							String otherName = data.mapper.mapName(method);
-							if (otherName.equals(mappedName)) {
-								allDescriptorsInTargets.add(data.mapper.mapDesc(method));
-							}
-						}
-					}
-
-					if (allDescriptorsInTargets.equals(mappedDescriptors)) {
-						finalMembers.add(new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), mappedName, "*", ""));
-					} else {
-						for (String mappedDesc : mappedDescriptors) {
-							finalMembers.add(new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), mappedName, "", mappedDesc));
-						}
-					}
-				}
-			} else {
-				for (Map.Entry<String, SortedSet<String>> entry : descriptorsForName.entrySet()) {
-					String mappedName = entry.getKey();
-					Set<String> mappedDescriptors = entry.getValue();
-
+				if (!wantDesc && canInject(mappedName, fullMethodToTarget)) { // Try to apply method name without descriptor if possible
+					list.add(new MemberInfo(mappedOwner, mappedName, info.getQuantifier(), ""));
+				} else {
 					for (String mappedDesc : mappedDescriptors) {
-						finalMembers.add(new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), mappedName, "", mappedDesc));
+						if (canInject(mappedName, mappedDesc, fullMethodToTarget)) {
+							String quantifier = info.getQuantifier();
+							if (quantifier.equals("*") || quantifier.startsWith("{0,")) {
+								quantifier = "";
+							}
+							list.add(new MemberInfo(mappedOwner, mappedName, quantifier, mappedDesc));
+						} else {
+							data.getLogger().error(Message.MISSING_INJECT, info.toString(), mappedName, mappedDesc);
+						}
 					}
 				}
 			}
 
-			return finalMembers;
-		}
-
-		private MemberInfo singleResult() {
-			List<Pair<String, String>> collection = targets.stream()
-			   .map(target -> resolvePartial(target, info.getName(), info.getDesc()))
-			   .filter(Optional::isPresent)
-			   .map(Optional::get)
-			   .map(m -> Pair.of(data.mapper.mapName(m), data.mapper.mapDesc(m)))
-			   .distinct()
-			   .collect(Collectors.toList());
-
-			if (collection.size() > 1) {
-				data.getLogger().error(Message.CONFLICT_MAPPING, info.getName(), collection);
-			} else if (collection.isEmpty()) {
-				data.getLogger().warn(Message.NO_MAPPING_NON_RECURSIVE, info.getName(), targets);
-				return info;
+			if (list.isEmpty()) {
+				return Collections.singletonList(info);
 			}
 
-			Pair<String, String> pair = collection.get(0);
-			String mappedName = pair.first();
-
-			boolean useDescriptor = !info.getDesc().isEmpty() || isNameAmbiguous(mappedName, pair.second());
-			String desc = useDescriptor ? pair.second() : "";
-
-			return new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), mappedName, info.getQuantifier(), desc);
+			return list;
 		}
 
-		private boolean isNameAmbiguous(String mappedName, String mappedDesc) {
-			// Try to find a method with the same name, but a different descriptor
-
+		private boolean canInject(String mappedName, Map<Pair<String, String>, Set<TrClass>> fullMethodToTarget) {
 			for (TrClass target : targets) {
 				for (TrMethod method : target.getMethods()) {
 					String otherName = data.mapper.mapName(method);
-					if (otherName.equals(mappedName)) { // Same name
-						String otherDesc = data.mapper.mapDesc(method);
-						if (!otherDesc.equals(mappedDesc)) { // Different descriptor
-							return true;
-						}
+					if (!otherName.equals(mappedName)) {
+						continue;
+					}
+
+					String otherDesc = data.mapper.mapDesc(method);
+					Pair<String, String> pair = Pair.of(otherName, otherDesc);
+					Set<TrClass> validClasses = fullMethodToTarget.get(pair);
+					if (validClasses == null || !validClasses.contains(target)) {
+						return false;
 					}
 				}
 			}
 
-			return false;
+			return true;
+		}
+
+		private boolean canInject(String mappedName, String mappedDesc, Map<Pair<String, String>, Set<TrClass>> fullMethodToTarget) {
+			Pair<String, String> pair = Pair.of(mappedName, mappedDesc);
+			Set<TrClass> validClasses = fullMethodToTarget.get(pair);
+			if (validClasses == null || validClasses.isEmpty()) {
+				return false;
+			}
+
+			for (TrClass target : targets) {
+				TrMethod method = target.getMethod(mappedName, mappedDesc);
+				if (method != null && !validClasses.contains(target)) {
+					return false;
+				}
+			}
+
+			return true;
 		}
 	}
+
+	// Code based on Mixin Quantifier parsing code
+	// Copyright (c) SpongePowered <https://www.spongepowered.org>
+	// Copyright (c) contributors
+	// https://github.com/FabricMC/Mixin/blob/e4edb3afad347f7561acf6a9dd4a64f2aa479658/src/main/java/org/spongepowered/asm/util/Quantifier.java
+	private static int quantifierStringToMax(String quantifier) {
+		if (quantifier == null || quantifier.isEmpty()) {
+			return 1;
+		}
+		if (quantifier.equals("*") || quantifier.equals("+")) {
+			return Integer.MAX_VALUE;
+		}
+		if (!quantifier.startsWith("{") || !quantifier.endsWith("}") || quantifier.length() < 3) {
+			return 0;
+		}
+
+		String inner = quantifier.substring(1, quantifier.length() - 1).trim();
+		if (inner.isEmpty()) {
+			return 0;
+		}
+
+		String strMax = inner;
+
+		int comma = inner.indexOf(',');
+		if (comma > -1) {
+			strMax = inner.substring(comma + 1).trim();
+		}
+
+		try {
+			return !strMax.isEmpty() ? Integer.parseInt(strMax) : Integer.MAX_VALUE;
+		} catch (NumberFormatException ex) {
+			return 0;
+		}
+
+	}
+
+
+
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -224,7 +226,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 				return new MemberInfo[] { info };
 			}
 
-			Map<String, Set<String>> descriptorsForName = new TreeMap<>();
+			SortedMap<String, SortedSet<String>> descriptorsForName = new TreeMap<>();
 			for (Pair<String, String> pair : collection) {
 				descriptorsForName.computeIfAbsent(pair.first(), k -> new TreeSet<>()).add(pair.second());
 			}
@@ -236,7 +238,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 				// However, we can only do this if all the methods in the source namespace
 				// are exactly matched in the target namespace
 
-				for (Map.Entry<String, Set<String>> entry : descriptorsForName.entrySet()) {
+				for (Map.Entry<String, SortedSet<String>> entry : descriptorsForName.entrySet()) {
 					String mappedName = entry.getKey();
 					Set<String> mappedDescriptors = entry.getValue();
 
@@ -260,7 +262,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 					}
 				}
 			} else {
-				for (Map.Entry<String, Set<String>> entry : descriptorsForName.entrySet()) {
+				for (Map.Entry<String, SortedSet<String>> entry : descriptorsForName.entrySet()) {
 					String mappedName = entry.getKey();
 					Set<String> mappedDescriptors = entry.getValue();
 

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -277,6 +277,10 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 		}
 
 		private boolean canInject(String mappedName, int methodsPerTarget, Set<String> neededDescriptors, Map<Pair<String, String>, Set<TrClass>> fullMethodToTarget) {
+			if (methodsPerTarget <= 0) {
+				throw new IllegalArgumentException();
+			}
+
 			for (TrClass target : targets) {
 				int toCheck = methodsPerTarget;
 
@@ -286,13 +290,6 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 					String otherName = data.mapper.mapName(method);
 					if (!otherName.equals(mappedName)) {
 						continue;
-					}
-
-					// We only break if methodsPerTarget > 1 in order to disambiguate even when unnecessary due to implicit limit of 1
-					// e.g. If targeting method foo in [foo, bar -> baz, baz], we want to disambiguate the baz even though we would be
-					// targeting the correct method due to the max limit
-					if (toCheck <= 0 && methodsPerTarget > 1) {
-						break;
 					}
 
 					String otherDesc = data.mapper.mapDesc(method);
@@ -306,7 +303,13 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 						return false;
 					}
 
+					// We only break if methodsPerTarget > 1 in order to disambiguate even when unnecessary due to implicit limit of 1
+					// e.g. If targeting method foo in [foo, bar -> baz, baz], we want to disambiguate the baz even though we would be
+					// targeting the correct method due to the max limit
 					toCheck -= 1;
+					if (toCheck <= 0 && methodsPerTarget > 1) {
+						break;
+					}
 				}
 
 				// This check is needed because we might be mapping a -> b,

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -255,7 +255,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 						finalMembers.add(new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), mappedName, "*", ""));
 					} else {
 						for (String mappedDesc : mappedDescriptors) {
-							finalMembers.add(new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), mappedName, "*", mappedDesc));
+							finalMembers.add(new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), mappedName, "", mappedDesc));
 						}
 					}
 				}
@@ -265,7 +265,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 					Set<String> mappedDescriptors = entry.getValue();
 
 					for (String mappedDesc : mappedDescriptors) {
-						finalMembers.add(new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), mappedName, "*", mappedDesc));
+						finalMembers.add(new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), mappedName, "", mappedDesc));
 					}
 				}
 			}

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -241,19 +241,19 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 
 			List<MemberInfo> list = new ArrayList<>();
 
-			boolean wantDesc = !info.getDesc().isEmpty();
+			boolean explicitDesc = !info.getDesc().isEmpty();
 
 			for (Map.Entry<String, SortedSet<String>> entry : namesToDesc.entrySet()) {
 				String mappedName = entry.getKey();
 				SortedSet<String> mappedDescriptors = entry.getValue();
 
-				if (!wantDesc && canInject(mappedName, fullMethodToTarget)) { // Try to apply method name without descriptor if possible
+				if (!explicitDesc && canInject(mappedName, methodsPerTarget, mappedDescriptors, fullMethodToTarget)) { // Try to apply method name without descriptor if possible
 					list.add(new MemberInfo(mappedOwner, mappedName, info.getQuantifier(), ""));
 				} else {
 					for (String mappedDesc : mappedDescriptors) {
 						if (canInject(mappedName, mappedDesc, fullMethodToTarget)) {
 							String quantifier = info.getQuantifier();
-							if (quantifier.equals("*") || quantifier.startsWith("{0,")) {
+							if (!explicitDesc) {
 								quantifier = "";
 							}
 							list.add(new MemberInfo(mappedOwner, mappedName, quantifier, mappedDesc));
@@ -271,18 +271,41 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 			return list;
 		}
 
-		private boolean canInject(String mappedName, Map<Pair<String, String>, Set<TrClass>> fullMethodToTarget) {
+		private boolean canInject(String mappedName, int methodsPerTarget, Set<String> neededDescriptors, Map<Pair<String, String>, Set<TrClass>> fullMethodToTarget) {
 			for (TrClass target : targets) {
+				int toCheck = methodsPerTarget;
+
+				Set<String> missingDescriptors = new HashSet<>(neededDescriptors);
+
 				for (TrMethod method : target.getMethods()) {
 					String otherName = data.mapper.mapName(method);
 					if (!otherName.equals(mappedName)) {
 						continue;
 					}
 
+					toCheck -= 1;
+					if (toCheck <= 0) {
+						break;
+					}
+
 					String otherDesc = data.mapper.mapDesc(method);
+					missingDescriptors.remove(otherDesc);
+
 					Pair<String, String> pair = Pair.of(otherName, otherDesc);
 					Set<TrClass> validClasses = fullMethodToTarget.get(pair);
 					if (validClasses == null || !validClasses.contains(target)) {
+						return false;
+					}
+				}
+
+				// This check is needed because we might be mapping a -> b,
+				// but another method b exists in the target class at an earlier position
+				// In this case, we can't use b without a descriptor because it'll target
+				// the earlier method instead of the method we want
+				for (String missingDesc : missingDescriptors) {
+					Pair<String, String> pair = Pair.of(mappedName, missingDesc);
+					Set<TrClass> validClasses = fullMethodToTarget.get(pair);
+					if (validClasses != null && validClasses.contains(target)) {
 						return false;
 					}
 				}

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -192,6 +192,15 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 			return owner.resolveMethods(name, desc, false, null, null);
 		}
 
+		@Override
+		public MemberInfo[] result() {
+			if (info.getQuantifier().equals("*")) {
+				return this.wildcardResult();
+			} else {
+				return new MemberInfo[] { singleResult() };
+			}
+		}
+
 		private MemberInfo[] wildcardResult() {
 			// Special case to remap the desc of wildcards without a name, such as `*()Lcom/example/ClassName;`
 			if (info.getName().isEmpty() && !info.getDesc().isEmpty()) {
@@ -309,15 +318,6 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 			}
 
 			return false;
-		}
-
-		@Override
-		public MemberInfo[] result() {
-			if (info.getQuantifier().equals("*")) {
-				return this.wildcardResult();
-			} else {
-				return new MemberInfo[] { singleResult() };
-			}
 		}
 	}
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -18,10 +18,17 @@
 
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import org.objectweb.asm.AnnotationVisitor;
@@ -85,11 +92,23 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 			return new AnnotationVisitor(Constant.ASM_VERSION, av) {
 				@Override
 				public void visit(String name, Object value) {
-					Optional<MemberInfo> info = Optional.ofNullable(MemberInfo.parse(Objects.requireNonNull((String) value).replaceAll("\\s", "")));
+					String string = Objects.requireNonNull((String) value);
 
-					value = info.map(i -> new InjectMethodMappable(data, i, targets).result().toString()).orElse((String) value);
+					MemberInfo info = MemberInfo.parse(string.replaceAll("\\s", ""));
 
-					super.visit(name, value);
+					if (info == null) {
+						super.visit(name, value);
+						return;
+					}
+
+					MemberInfo[] resolved = new InjectMethodMappable(data, info, targets).result();
+					if (resolved.length == 0) {
+						throw new RuntimeException("InjectMethodMappable should never resolve to zero entries");
+					}
+
+					for (MemberInfo memberInfos : resolved) {
+						super.visit(name, memberInfos.toString());
+					}
 				}
 			};
 		} else if (name.equals(AnnotationElement.TARGET)) {	// All
@@ -133,7 +152,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 		return av;
 	}
 
-	private static class InjectMethodMappable implements IMappable<MemberInfo> {
+	private static class InjectMethodMappable implements IMappable<MemberInfo[]> {
 		private final CommonData data;
 		private final MemberInfo info;
 		private final List<TrClass> targets;
@@ -161,52 +180,144 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 			name = name.isEmpty() ? null : name;
 			desc = desc.isEmpty() ? null : desc;
 
-			return data.resolver.resolveMethod(owner, name, desc, ResolveUtility.FLAG_FIRST | ResolveUtility.FLAG_NON_SYN).map(m -> m);
+			return data.resolver.resolveMethod(owner, name, desc, ResolveUtility.FLAG_FIRST).map(m -> m);
 		}
 
-		@Override
-		public MemberInfo result() {
+		private Collection<TrMethod> resolvePartials(TrClass owner, String name, String desc) {
+			Objects.requireNonNull(owner);
+
+			name = name.isEmpty() ? null : name;
+			desc = desc.isEmpty() ? null : desc;
+
+			return owner.resolveMethods(name, desc, false, null, null);
+		}
+
+		private MemberInfo[] wildcardResult() {
 			// Special case to remap the desc of wildcards without a name, such as `*()Lcom/example/ClassName;`
-			if (info.getOwner().isEmpty()
-					&& info.getName().isEmpty()
-					&& info.getQuantifier().equals("*")
-					&& !info.getDesc().isEmpty()) {
-				return new MemberInfo(info.getOwner(), info.getName(), info.getQuantifier(), data.mapper.asTrRemapper().mapDesc(info.getDesc()));
+			if (info.getName().isEmpty() && !info.getDesc().isEmpty()) {
+				return new MemberInfo[] {
+					new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), info.getName(), "*", data.mapper.asTrRemapper().mapDesc(info.getDesc()))
+				};
 			}
 
+			if (targets.isEmpty() || info.getName().isEmpty()) {
+				return new MemberInfo[] { info };
+			}
+
+			List<Pair<String, String>> collection = targets.stream()
+			   .flatMap(target -> resolvePartials(target, info.getName(), info.getDesc()).stream())
+			   .map(m -> Pair.of(data.mapper.mapName(m), data.mapper.mapDesc(m)))
+			   .distinct()
+			   .collect(Collectors.toList());
+
+			if (collection.isEmpty()) {
+				data.getLogger().warn(Message.NO_MAPPING_NON_RECURSIVE, info.getName(), targets);
+				return new MemberInfo[] { info };
+			}
+
+			Map<String, Set<String>> descriptorsForName = new TreeMap<>();
+			for (Pair<String, String> pair : collection) {
+				descriptorsForName.computeIfAbsent(pair.first(), k -> new TreeSet<>()).add(pair.second());
+			}
+
+			List<MemberInfo> finalMembers = new ArrayList<>();
+
+			if (info.getDesc().isEmpty()) {
+				// If the descriptor was omitted in the input, we want to omit the descriptor in the output as well
+				// However, we can only do this if all the methods in the source namespace
+				// are exactly matched in the target namespace
+
+				for (Map.Entry<String, Set<String>> entry : descriptorsForName.entrySet()) {
+					String mappedName = entry.getKey();
+					Set<String> mappedDescriptors = entry.getValue();
+
+					Set<String> allDescriptorsInTargets = new HashSet<>();
+
+					for (TrClass target : targets) {
+						for (TrMethod method : target.getMethods()) {
+							String otherName = data.mapper.mapName(method);
+							if (otherName.equals(mappedName)) {
+								allDescriptorsInTargets.add(data.mapper.mapDesc(method));
+							}
+						}
+					}
+
+					if (allDescriptorsInTargets.equals(mappedDescriptors)) {
+						finalMembers.add(new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), mappedName, "*", ""));
+					} else {
+						for (String mappedDesc : mappedDescriptors) {
+							finalMembers.add(new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), mappedName, "*", mappedDesc));
+						}
+					}
+				}
+			} else {
+				for (Map.Entry<String, Set<String>> entry : descriptorsForName.entrySet()) {
+					String mappedName = entry.getKey();
+					Set<String> mappedDescriptors = entry.getValue();
+
+					for (String mappedDesc : mappedDescriptors) {
+						finalMembers.add(new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), mappedName, "*", mappedDesc));
+					}
+				}
+			}
+
+			return finalMembers.toArray(new MemberInfo[0]);
+		}
+
+		private MemberInfo singleResult() {
 			if (targets.isEmpty() || info.getName().isEmpty()) {
 				return info;
 			}
 
 			List<Pair<String, String>> collection = targets.stream()
-					.map(target -> resolvePartial(target, info.getName(), info.getDesc()))
-					.filter(Optional::isPresent)
-					.map(Optional::get)
-					.map(m -> {
-						String mappedName = data.mapper.mapName(m);
-						boolean shouldPassDesc = false;
-
-						for (TrMethod other : m.getOwner().getMethods()) { // look for ambiguous targets
-							if (other == m) continue;
-
-							if (data.mapper.mapName(other).equals(mappedName)) {
-								shouldPassDesc = true;
-							}
-						}
-
-						return Pair.of(mappedName, shouldPassDesc ? data.mapper.mapDesc(m) : "");
-					})
-					.distinct().collect(Collectors.toList());
+			   .map(target -> resolvePartial(target, info.getName(), info.getDesc()))
+			   .filter(Optional::isPresent)
+			   .map(Optional::get)
+			   .map(m -> Pair.of(data.mapper.mapName(m), data.mapper.mapDesc(m)))
+			   .distinct()
+			   .collect(Collectors.toList());
 
 			if (collection.size() > 1) {
 				data.getLogger().error(Message.CONFLICT_MAPPING, info.getName(), collection);
 			} else if (collection.isEmpty()) {
 				data.getLogger().warn(Message.NO_MAPPING_NON_RECURSIVE, info.getName(), targets);
+				return info;
 			}
 
-			return collection.stream().findFirst()
-					.map(pair -> new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), pair.first(), info.getQuantifier(), info.getQuantifier().equals("*") ? "" : pair.second()))
-					.orElse(info);
+			Pair<String, String> pair = collection.get(0);
+			String mappedName = pair.first();
+
+			boolean useDescriptor = !info.getDesc().isEmpty() || isNameAmbiguous(mappedName, pair.second());
+			String desc = useDescriptor ? pair.second() : "";
+
+			return new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), mappedName, info.getQuantifier(), desc);
+		}
+
+		private boolean isNameAmbiguous(String mappedName, String mappedDesc) {
+			// Try to find a method with the same name, but a different descriptor
+
+			for (TrClass target : targets) {
+				for (TrMethod method : target.getMethods()) {
+					String otherName = data.mapper.mapName(method);
+					if (otherName.equals(mappedName)) { // Same name
+						String otherDesc = data.mapper.mapDesc(method);
+						if (!otherDesc.equals(mappedDesc)) { // Different descriptor
+							return true;
+						}
+					}
+				}
+			}
+
+			return false;
+		}
+
+		@Override
+		public MemberInfo[] result() {
+			if (info.getQuantifier().equals("*")) {
+				return this.wildcardResult();
+			} else {
+				return new MemberInfo[] { singleResult() };
+			}
 		}
 	}
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -197,7 +197,9 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 				mappedOwner = data.mapper.asTrRemapper().map(mappedOwner);
 			}
 
-			int methodsPerTarget = quantifierStringToMax(info.getQuantifier());
+			Pair<Integer, Integer> parsedQuantifier = parseQuantifier(data, info.getQuantifier());
+			int quantifierMin = parsedQuantifier.first();
+			int methodsPerTarget = parsedQuantifier.second();
 
 			if (targets.isEmpty() || info.getName().isEmpty() || methodsPerTarget <= 0) {
 				// Simple case when we can't find the specific method by name
@@ -254,6 +256,9 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 						if (canInject(mappedName, mappedDesc, fullMethodToTarget)) {
 							String quantifier = info.getQuantifier();
 							if (!explicitDesc) {
+								if (quantifierMin > 0) {
+									data.getLogger().error(Message.UNSUPPORTED_QUANTIFIER_MIN, info.toString());
+								}
 								quantifier = "";
 							}
 							list.add(new MemberInfo(mappedOwner, mappedName, quantifier, mappedDesc));
@@ -336,33 +341,43 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 	// Copyright (c) SpongePowered <https://www.spongepowered.org>
 	// Copyright (c) contributors
 	// https://github.com/FabricMC/Mixin/blob/e4edb3afad347f7561acf6a9dd4a64f2aa479658/src/main/java/org/spongepowered/asm/util/Quantifier.java
-	private static int quantifierStringToMax(String quantifier) {
+	private static Pair<Integer, Integer> parseQuantifier(CommonData data, String quantifier) {
 		if (quantifier == null || quantifier.isEmpty()) {
-			return 1;
+			return Pair.of(0, 1);
 		}
-		if (quantifier.equals("*") || quantifier.equals("+")) {
-			return Integer.MAX_VALUE;
+		if (quantifier.equals("*")) {
+			return Pair.of(0, Integer.MAX_VALUE);
+		}
+		if (quantifier.equals("+")) {
+			return Pair.of(1, Integer.MAX_VALUE);
 		}
 		if (!quantifier.startsWith("{") || !quantifier.endsWith("}") || quantifier.length() < 3) {
-			return 0;
+			data.getLogger().error(Message.UNABLE_TO_PARSE_QUANTIFIER, quantifier);
+			return Pair.of(0, 0);
 		}
 
 		String inner = quantifier.substring(1, quantifier.length() - 1).trim();
 		if (inner.isEmpty()) {
-			return 0;
+			data.getLogger().error(Message.UNABLE_TO_PARSE_QUANTIFIER, quantifier);
+			return Pair.of(0, 0);
 		}
 
+		String strMin = inner;
 		String strMax = inner;
 
 		int comma = inner.indexOf(',');
 		if (comma > -1) {
+			strMin = inner.substring(0, comma).trim();
 			strMax = inner.substring(comma + 1).trim();
 		}
 
 		try {
-			return !strMax.isEmpty() ? Integer.parseInt(strMax) : Integer.MAX_VALUE;
+			int min = !strMin.isEmpty() ? Integer.parseInt(strMin) : 0;
+			int max = !strMax.isEmpty() ? Integer.parseInt(strMax) : Integer.MAX_VALUE;
+			return Pair.of(min, Math.max(min, max));
 		} catch (NumberFormatException ex) {
-			return 0;
+			data.getLogger().error(Message.UNABLE_TO_PARSE_QUANTIFIER, quantifier);
+			return Pair.of(0, 0);
 		}
 
 	}

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -103,8 +103,8 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 						return;
 					}
 
-					MemberInfo[] resolved = new InjectMethodMappable(data, info, targets).result();
-					if (resolved.length == 0) {
+					List<MemberInfo> resolved = new InjectMethodMappable(data, info, targets).result();
+					if (resolved.isEmpty()) {
 						throw new RuntimeException("InjectMethodMappable should never resolve to zero entries");
 					}
 
@@ -154,7 +154,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 		return av;
 	}
 
-	private static class InjectMethodMappable implements IMappable<MemberInfo[]> {
+	private static class InjectMethodMappable implements IMappable<List<MemberInfo>> {
 		private final CommonData data;
 		private final MemberInfo info;
 		private final List<TrClass> targets;
@@ -195,7 +195,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 		}
 
 		@Override
-		public MemberInfo[] result() {
+		public List<MemberInfo> result() {
 			if (targets.isEmpty() || info.getName().isEmpty()) {
 				// Simple case when we can't find the specific method by name
 
@@ -204,19 +204,17 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 					desc = data.mapper.asTrRemapper().mapDesc(desc);
 				}
 
-				return new MemberInfo[] {
-					new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), info.getName(), info.getQuantifier(), desc)
-				};
+				return Collections.singletonList(new MemberInfo(data.mapper.asTrRemapper().map(info.getOwner()), info.getName(), info.getQuantifier(), desc));
 			}
 
 			if (info.getQuantifier().equals("*")) {
 				return this.wildcardResult();
 			} else {
-				return new MemberInfo[] { singleResult() };
+				return Collections.singletonList(singleResult());
 			}
 		}
 
-		private MemberInfo[] wildcardResult() {
+		private List<MemberInfo> wildcardResult() {
 			List<Pair<String, String>> collection = targets.stream()
 			   .flatMap(target -> resolvePartials(target, info.getName(), info.getDesc()).stream())
 			   .map(m -> Pair.of(data.mapper.mapName(m), data.mapper.mapDesc(m)))
@@ -225,7 +223,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 
 			if (collection.isEmpty()) {
 				data.getLogger().warn(Message.NO_MAPPING_NON_RECURSIVE, info.getName(), targets);
-				return new MemberInfo[] { info };
+				return Collections.singletonList(info);
 			}
 
 			SortedMap<String, SortedSet<String>> descriptorsForName = new TreeMap<>();
@@ -274,7 +272,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 				}
 			}
 
-			return finalMembers.toArray(new MemberInfo[0]);
+			return finalMembers;
 		}
 
 		private MemberInfo singleResult() {

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -249,7 +249,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 				String mappedName = entry.getKey();
 				SortedSet<String> mappedDescriptors = entry.getValue();
 
-				if (!explicitDesc && canInject(mappedName, methodsPerTarget, mappedDescriptors, fullMethodToTarget)) { // Try to apply method name without descriptor if possible
+				if (!explicitDesc && canInject(mappedName, methodsPerTarget, fullMethodToTarget)) { // Try to apply method name without descriptor if possible
 					list.add(new MemberInfo(mappedOwner, mappedName, info.getQuantifier(), ""));
 				} else {
 					for (String mappedDesc : mappedDescriptors) {
@@ -276,15 +276,13 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 			return list;
 		}
 
-		private boolean canInject(String mappedName, int methodsPerTarget, Set<String> neededDescriptors, Map<Pair<String, String>, Set<TrClass>> fullMethodToTarget) {
+		private boolean canInject(String mappedName, int methodsPerTarget, Map<Pair<String, String>, Set<TrClass>> fullMethodToTarget) {
 			if (methodsPerTarget <= 0) {
 				throw new IllegalArgumentException();
 			}
 
 			for (TrClass target : targets) {
 				int toCheck = methodsPerTarget;
-
-				Set<String> missingDescriptors = new HashSet<>(neededDescriptors);
 
 				for (TrMethod method : target.getMethods()) {
 					String otherName = data.mapper.mapName(method);
@@ -293,9 +291,6 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 					}
 
 					String otherDesc = data.mapper.mapDesc(method);
-					if (toCheck > 0) {
-						missingDescriptors.remove(otherDesc);
-					}
 
 					Pair<String, String> pair = Pair.of(otherName, otherDesc);
 					Set<TrClass> validClasses = fullMethodToTarget.get(pair);
@@ -309,18 +304,6 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 					toCheck -= 1;
 					if (toCheck <= 0 && methodsPerTarget > 1) {
 						break;
-					}
-				}
-
-				// This check is needed because we might be mapping a -> b,
-				// but another method b exists in the target class at an earlier position
-				// In this case, we can't use b without a descriptor because it'll target
-				// the earlier method instead of the method we want
-				for (String missingDesc : missingDescriptors) {
-					Pair<String, String> pair = Pair.of(mappedName, missingDesc);
-					Set<TrClass> validClasses = fullMethodToTarget.get(pair);
-					if (validClasses != null && validClasses.contains(target)) {
-						return false;
 					}
 				}
 			}

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/MixinIntegrationTest.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/MixinIntegrationTest.java
@@ -75,8 +75,8 @@ public class MixinIntegrationTest {
 		// *()Ljava/lang/String; -> *()Lcom/example/NotString;
 		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/Inject;(method={\"*()Lcom/example/NotString;\"}"));
 		// Check that wildcards are expanded with descriptor to avoid incorrect targets (targetB)
-		// targetA* -> {"sameName*()Lcom/example/NotString;", "sameName*(Ljava/lang/Object;)V"}
-		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/Inject;(method={\"sameName*()Lcom/example/NotString;\", \"sameName*(Ljava/lang/Object;)V\"}"));
+		// targetA* -> {"sameName()Lcom/example/NotString;", "sameName(Ljava/lang/Object;)V"}
+		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/Inject;(method={\"sameName()Lcom/example/NotString;\", \"sameName(Ljava/lang/Object;)V\"}"));
 	}
 
 	@Test
@@ -106,9 +106,6 @@ public class MixinIntegrationTest {
 		// full signature is used to disambiguate names
 		// addString -> add(Ljava/lang/String;)V
 		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/Inject;(method={\"add(Ljava/lang/String;)V\""));
-		// ensure full signature is used for wildcard as well
-		// addString* -> add*(Ljava/lang/String;)V
-		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/Inject;(method={\"add*(Ljava/lang/String;)V\"}"));
 	}
 
 	@Test

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/MixinIntegrationTest.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/MixinIntegrationTest.java
@@ -45,11 +45,13 @@ import net.fabricmc.tinyremapper.extension.mixin.integration.mixins.AmbiguousRem
 import net.fabricmc.tinyremapper.extension.mixin.integration.mixins.DescAtMixin;
 import net.fabricmc.tinyremapper.extension.mixin.integration.mixins.LvtRemapTargetMixin;
 import net.fabricmc.tinyremapper.extension.mixin.integration.mixins.NonObfuscatedOverrideMixin;
+import net.fabricmc.tinyremapper.extension.mixin.integration.mixins.SeparateRemappedNameMixin;
 import net.fabricmc.tinyremapper.extension.mixin.integration.mixins.WildcardTargetMixin;
 import net.fabricmc.tinyremapper.extension.mixin.integration.targets.AmbiguousRemappedNameTarget;
 import net.fabricmc.tinyremapper.extension.mixin.integration.targets.DescAtTarget;
 import net.fabricmc.tinyremapper.extension.mixin.integration.targets.LvtRemapTarget;
 import net.fabricmc.tinyremapper.extension.mixin.integration.targets.NonObfuscatedOverrideTarget;
+import net.fabricmc.tinyremapper.extension.mixin.integration.targets.SeparateRemappedNameTarget;
 import net.fabricmc.tinyremapper.extension.mixin.integration.targets.WildcardTarget;
 
 public class MixinIntegrationTest {
@@ -58,13 +60,23 @@ public class MixinIntegrationTest {
 
 	@Test
 	public void remapWildcardName() throws IOException {
-		String remapped = remap(WildcardTarget.class, WildcardTargetMixin.class, out ->
-				out.acceptClass("java/lang/String", "com/example/NotString"));
+		String remapped = remap(WildcardTarget.class, WildcardTargetMixin.class, out -> {
+			String fqn = "net/fabricmc/tinyremapper/extension/mixin/integration/targets/WildcardTarget";
+			out.acceptClass("java/lang/String", "com/example/NotString");
+			out.acceptMethod(new IMappingProvider.Member(fqn, "targetA", "(Ljava/lang/Object;)V"), "sameName");
+			out.acceptMethod(new IMappingProvider.Member(fqn, "targetA", "()Ljava/lang/String;"), "sameName");
+			out.acceptMethod(new IMappingProvider.Member(fqn, "targetB", "()Ljava/lang/Object;"), "sameName");
+		});
 
 		// Check constructor inject did not gain a desc
+		// <init>* -> <init>*
 		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/Inject;(method={\"<init>*\"}"));
 		// Check that wildcard desc is remapped without a name
+		// *()Ljava/lang/String; -> *()Lcom/example/NotString;
 		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/Inject;(method={\"*()Lcom/example/NotString;\"}"));
+		// Check that wildcards are expanded with descriptor to avoid incorrect targets (targetB)
+		// targetA* -> {"sameName*()Lcom/example/NotString;", "sameName*(Ljava/lang/Object;)V"}
+		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/Inject;(method={\"sameName*()Lcom/example/NotString;\", \"sameName*(Ljava/lang/Object;)V\"}"));
 	}
 
 	@Test
@@ -83,7 +95,7 @@ public class MixinIntegrationTest {
 	}
 
 	@Test
-	public void remapAmbiuousRemappedName() throws IOException {
+	public void remapAmbiguousRemappedName() throws IOException {
 		String remapped = remap(AmbiguousRemappedNameTarget.class, AmbiguousRemappedNameMixin.class, out -> {
 			String fqn = "net/fabricmc/tinyremapper/extension/mixin/integration/targets/AmbiguousRemappedNameTarget";
 			out.acceptClass(fqn, "com/example/Remapped");
@@ -92,7 +104,30 @@ public class MixinIntegrationTest {
 		});
 
 		// full signature is used to disambiguate names
+		// addString -> add(Ljava/lang/String;)V
 		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/Inject;(method={\"add(Ljava/lang/String;)V\""));
+		// ensure full signature is used for wildcard as well
+		// addString* -> add*(Ljava/lang/String;)V
+		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/Inject;(method={\"add*(Ljava/lang/String;)V\"}"));
+	}
+
+	@Test
+	public void remapSeparateRemappedName() throws IOException {
+		String remapped = remap(SeparateRemappedNameTarget.class, SeparateRemappedNameMixin.class, out -> {
+			String fqn = "net/fabricmc/tinyremapper/extension/mixin/integration/targets/SeparateRemappedNameTarget";
+			out.acceptMethod(new IMappingProvider.Member(fqn, "addString", "(Ljava/lang/String;)V"), "add1");
+			out.acceptMethod(new IMappingProvider.Member(fqn, "addString", "(Ljava/lang/String;I)V"), "add2");
+		});
+
+		// Ensure that descriptor isn't added and first method is targeted
+		// addString -> add1
+		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/Inject;(method={\"add1\"}"));
+		// Ensure that descriptor is kept and second method is targeted
+		// addString(Ljava/lang/String;I)V -> add2(Ljava/lang/String;I)V
+		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/Inject;(method={\"add2(Ljava/lang/String;I)V\"}"));
+		// Ensure that both methods are targeted by wildcard
+		// addString* -> {"add1*", "add2*"}
+		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/Inject;(method={\"add1*\", \"add2*\"}"));
 	}
 
 	@Test

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/AmbiguousRemappedNameMixin.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/AmbiguousRemappedNameMixin.java
@@ -30,8 +30,4 @@ public class AmbiguousRemappedNameMixin {
 	@Inject(method = "addString", at = @At("HEAD"))
 	private void injectAddString(String string, CallbackInfo ci) {
 	}
-
-	@Inject(method = "addString*", at = @At("HEAD"))
-	private void injectAddStringWildcard(String string, CallbackInfo ci) {
-	}
 }

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/SeparateRemappedNameMixin.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/SeparateRemappedNameMixin.java
@@ -18,20 +18,24 @@
 
 package net.fabricmc.tinyremapper.extension.mixin.integration.mixins;
 
+import net.fabricmc.tinyremapper.extension.mixin.integration.targets.SeparateRemappedNameTarget;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.fabricmc.tinyremapper.extension.mixin.integration.targets.AmbiguousRemappedNameTarget;
-
-@Mixin(AmbiguousRemappedNameTarget.class)
-public class AmbiguousRemappedNameMixin {
+@Mixin(SeparateRemappedNameTarget.class)
+public class SeparateRemappedNameMixin {
 	@Inject(method = "addString", at = @At("HEAD"))
-	private void injectAddString(String string, CallbackInfo ci) {
+	private void injectAddStringFirst(String string, CallbackInfo ci) {
+	}
+
+	@Inject(method = "addString(Ljava/lang/String;I)V", at = @At("HEAD"))
+	private void injectAddStringSecond(String string, int value, CallbackInfo ci) {
 	}
 
 	@Inject(method = "addString*", at = @At("HEAD"))
-	private void injectAddStringWildcard(String string, CallbackInfo ci) {
+	private void injectAddStringBoth(CallbackInfo ci) {
 	}
 }

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/SeparateRemappedNameMixin.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/SeparateRemappedNameMixin.java
@@ -18,12 +18,12 @@
 
 package net.fabricmc.tinyremapper.extension.mixin.integration.mixins;
 
-import net.fabricmc.tinyremapper.extension.mixin.integration.targets.SeparateRemappedNameTarget;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.fabricmc.tinyremapper.extension.mixin.integration.targets.SeparateRemappedNameTarget;
 
 @Mixin(SeparateRemappedNameTarget.class)
 public class SeparateRemappedNameMixin {

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/WildcardTargetMixin.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/WildcardTargetMixin.java
@@ -35,4 +35,8 @@ public abstract class WildcardTargetMixin {
 	@Inject(method = "*()Ljava/lang/String;", at = @At("HEAD"), cancellable = true)
 	private void injectName(CallbackInfoReturnable<String> ci) {
 	}
+
+	@Inject(method = "targetA*", at = @At("HEAD"))
+	private void injectTargetA(CallbackInfo ci) {
+	}
 }

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/targets/SeparateRemappedNameTarget.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/targets/SeparateRemappedNameTarget.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2018, Player, asie
- * Copyright (c) 2025, FabricMC
+ * Copyright (c) 2026, FabricMC
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -18,30 +18,9 @@
 
 package net.fabricmc.tinyremapper.extension.mixin.integration.targets;
 
-public class WildcardTarget {
-	public WildcardTarget(String name) {
+public class SeparateRemappedNameTarget {
+	public void addString(String string) {
 	}
-
-	public WildcardTarget(String name, int other) {
-	}
-
-	public String getName() {
-		return "";
-	}
-
-	public String getRealName() {
-		return "";
-	}
-
-	// Both targetA and targetB will be remapped to 'sameName'
-	public void targetA(Object o) {
-	}
-
-	public String targetA() {
-		return null;
-	}
-
-	public Object targetB() {
-		return null;
+	public void addString(String string, int value) {
 	}
 }

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/targets/SeparateRemappedNameTarget.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/targets/SeparateRemappedNameTarget.java
@@ -21,6 +21,7 @@ package net.fabricmc.tinyremapper.extension.mixin.integration.targets;
 public class SeparateRemappedNameTarget {
 	public void addString(String string) {
 	}
+
 	public void addString(String string, int value) {
 	}
 }


### PR DESCRIPTION
### Fixed descriptor being dropped when input had descriptor

Descriptor should be used in output if and only if either:
1. Descriptor was present in input
2. Descriptor is necessary to disambiguate

### Added support for resolving multiple targets when using wildcard

See remapSeparateRemappedName test for example

### After the rewrite commit, this addresses a lot of additional problems and edge cases brought up by LlamaLad7 on discord
