### PR TITLE
Mixin regex remap in method selector

### DIFF
--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -19,6 +19,7 @@
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -39,6 +40,7 @@ import net.fabricmc.tinyremapper.extension.mixin.common.data.Constant;
 import net.fabricmc.tinyremapper.extension.mixin.common.data.Message;
 import net.fabricmc.tinyremapper.extension.mixin.common.data.Pair;
 import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
+import net.fabricmc.tinyremapper.extension.mixin.soft.util.RegexMatcher;
 
 /**
  * If the {@code method} element does not contain a name, then do not remap it; If the
@@ -85,7 +87,45 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 			return new AnnotationVisitor(Constant.ASM_VERSION, av) {
 				@Override
 				public void visit(String name, Object value) {
-					Optional<MemberInfo> info = Optional.ofNullable(MemberInfo.parse(Objects.requireNonNull((String) value).replaceAll("\\s", "")));
+					String string = Objects.requireNonNull((String) value).replaceAll("\\s", "");
+
+					// ending slash -> regex target
+					if (string.endsWith("/")) {
+						RegexMatcher matcher;
+
+						try {
+							matcher = RegexMatcher.parse(string);
+						} catch (RegexMatcher.ParsingException e) {
+							data.getLogger().warn("Error parsing mixin regex", e);
+							super.visit(name, value);
+							return;
+						}
+
+						List<? extends TrMethod> matchedMethods = Objects.requireNonNull(targets).stream()
+								.map(data.resolver::resolveClass)
+								.filter(Optional::isPresent)
+								.map(Optional::get)
+								.flatMap(trClass -> trClass.getMethods().stream())
+								.filter(trMethod -> matcher.matches(trMethod.getOwner().getName(), trMethod.getName(), trMethod.getDesc()))
+								.sorted(
+										Comparator
+												.<TrMethod, String>comparing(trMethod -> trMethod.getOwner().getName())
+												.thenComparing(TrMember::getName)
+												.thenComparing(TrMember::getDesc)
+								)
+								.collect(Collectors.toList());
+
+						for (TrMethod matchedMethod : matchedMethods) {
+							String mappedOwner = data.mapper.mapName(matchedMethod.getOwner());
+							String mappedName = data.mapper.mapName(matchedMethod);
+							String mappedDesc = data.mapper.mapDesc(matchedMethod);
+							super.visit(name, String.format("L%s;%s%s", mappedOwner, mappedName, mappedDesc));
+						}
+
+						return;
+					}
+
+					Optional<MemberInfo> info = Optional.ofNullable(MemberInfo.parse(string));
 
 					value = info.map(i -> new InjectMethodMappable(data, i, targets).result().toString()).orElse((String) value);
 

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -96,7 +96,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 			return new AnnotationVisitor(Constant.ASM_VERSION, av) {
 				@Override
 				public void visit(String name, Object value) {
-					String string = Objects.requireNonNull((String) value).replaceAll("\\s", "");
+					String string = Objects.requireNonNull((String) value);
 
 					// ending slash -> regex target
 					if (string.endsWith("/")) {
@@ -113,7 +113,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 						return;
 					}
 
-					MemberInfo info = MemberInfo.parse(string);
+					MemberInfo info = MemberInfo.parse(string.replaceAll("\\s", ""));
 
 					if (info == null) {
 						super.visit(name, value);

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -100,35 +100,14 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 
 					// ending slash -> regex target
 					if (string.endsWith("/")) {
-						RegexMatcher matcher;
+						List<String> resolved = resolveAndRemapMixinRegex(string);
 
-						try {
-							matcher = RegexMatcher.parse(string);
-						} catch (RegexMatcher.ParsingException e) {
-							data.getLogger().warn("Error parsing mixin regex", e);
+						if (resolved == null) {
 							super.visit(name, value);
-							return;
-						}
-
-						List<? extends TrMethod> matchedMethods = Objects.requireNonNull(targets).stream()
-								.map(data.resolver::resolveClass)
-								.filter(Optional::isPresent)
-								.map(Optional::get)
-								.flatMap(trClass -> trClass.getMethods().stream())
-								.filter(trMethod -> matcher.matches(trMethod.getOwner().getName(), trMethod.getName(), trMethod.getDesc()))
-								.sorted(
-										Comparator
-												.<TrMethod, String>comparing(trMethod -> trMethod.getOwner().getName())
-												.thenComparing(TrMember::getName)
-												.thenComparing(TrMember::getDesc)
-								)
-								.collect(Collectors.toList());
-
-						for (TrMethod matchedMethod : matchedMethods) {
-							String mappedOwner = data.mapper.mapName(matchedMethod.getOwner());
-							String mappedName = data.mapper.mapName(matchedMethod);
-							String mappedDesc = data.mapper.mapDesc(matchedMethod);
-							super.visit(name, String.format("L%s;%s%s", mappedOwner, mappedName, mappedDesc));
+						} else {
+							for (String remappedSelector : resolved) {
+								super.visit(name, remappedSelector);
+							}
 						}
 
 						return;
@@ -191,6 +170,42 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 		}
 
 		return av;
+	}
+
+	private List<String> resolveAndRemapMixinRegex(String input) {
+		RegexMatcher matcher;
+
+		try {
+			matcher = RegexMatcher.parse(input);
+		} catch (RegexMatcher.ParsingException e) {
+			data.getLogger().warn("Error parsing mixin regex %s: %s", input, e.toString());
+			return null;
+		}
+
+		List<? extends TrMethod> matchedMethods = Objects.requireNonNull(targets).stream()
+				.map(data.resolver::resolveClass)
+				.filter(Optional::isPresent)
+				.map(Optional::get)
+				.flatMap(trClass -> trClass.getMethods().stream())
+				.filter(trMethod -> matcher.matches(trMethod.getOwner().getName(), trMethod.getName(), trMethod.getDesc()))
+				.sorted(
+						Comparator
+								.<TrMethod, String>comparing(trMethod -> trMethod.getOwner().getName())
+								.thenComparing(TrMember::getName)
+								.thenComparing(TrMember::getDesc)
+				)
+				.collect(Collectors.toList());
+
+		List<String> result = new ArrayList<>();
+
+		for (TrMethod matchedMethod : matchedMethods) {
+			String mappedOwner = data.mapper.mapName(matchedMethod.getOwner());
+			String mappedName = data.mapper.mapName(matchedMethod);
+			String mappedDesc = data.mapper.mapDesc(matchedMethod);
+			result.add(String.format("L%s;%s%s", mappedOwner, mappedName, mappedDesc));
+		}
+
+		return result;
 	}
 
 	private static class InjectMethodMappable implements IMappable<List<MemberInfo>> {

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/util/RegexMatcher.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/util/RegexMatcher.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2016, 2018, Player, asie
+ * Copyright (c) 2026, FabricMC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.fabricmc.tinyremapper.extension.mixin.soft.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+public class RegexMatcher {
+	private static final Pattern PATTERN = Pattern.compile("((owner|name|desc)\\s*=\\s*)?/(.*?)(?<!\\\\)/");
+
+	private final Pattern owner;
+	private final Pattern name;
+	private final Pattern desc;
+
+	private RegexMatcher(Pattern owner, Pattern name, Pattern desc) {
+		this.owner = owner;
+		this.name = name;
+		this.desc = desc;
+	}
+
+	public static RegexMatcher parse(String input) throws ParsingException {
+		Matcher matcher = PATTERN.matcher(input);
+
+		Pattern owner = null;
+		Pattern name = null;
+		Pattern desc = null;
+
+		while (matcher.find()) {
+			Pattern pattern;
+
+			try {
+				pattern = Pattern.compile(matcher.group(3));
+			} catch (PatternSyntaxException e) {
+				throw new ParsingException(String.format("Error parsing pattern %s", matcher.group(3)), e);
+			}
+
+			String key = matcher.group(2);
+
+			if (key != null && key.equals("owner")) {
+				if (owner != null) {
+					throw new ParsingException(String.format("Duplicate owner field, old=/%s/, new=/%s/", owner.pattern(), pattern.pattern()));
+				} else {
+					owner = pattern;
+				}
+			} else if (key != null && key.equals("desc")) {
+				if (desc != null) {
+					throw new ParsingException(String.format("Duplicate desc field, old=/%s/, new=/%s/", desc.pattern(), pattern.pattern()));
+				} else {
+					desc = pattern;
+				}
+			} else {
+				if (name != null) {
+					throw new ParsingException(String.format("Duplicate name field, old=/%s/, new=/%s/", name.pattern(), pattern.pattern()));
+				} else {
+					name = pattern;
+				}
+			}
+		}
+
+		return new RegexMatcher(owner, name, desc);
+	}
+
+	public boolean matches(String owner, String name, String desc) {
+		return matches0(owner, this.owner) && matches0(name, this.name) && matches0(desc, this.desc);
+	}
+
+	private boolean matches0(String input, Pattern pattern) {
+		return pattern == null || input == null || pattern.matcher(input).find();
+	}
+
+	public static class ParsingException extends Exception {
+		public ParsingException(String message) {
+			super(message);
+		}
+
+		public ParsingException(String message, Throwable cause) {
+			super(message, cause);
+		}
+
+		public ParsingException(Throwable cause) {
+			super(cause);
+		}
+	}
+}

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/MixinIntegrationTest.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/MixinIntegrationTest.java
@@ -45,11 +45,13 @@ import net.fabricmc.tinyremapper.extension.mixin.integration.mixins.AmbiguousRem
 import net.fabricmc.tinyremapper.extension.mixin.integration.mixins.DescAtMixin;
 import net.fabricmc.tinyremapper.extension.mixin.integration.mixins.LvtRemapTargetMixin;
 import net.fabricmc.tinyremapper.extension.mixin.integration.mixins.NonObfuscatedOverrideMixin;
+import net.fabricmc.tinyremapper.extension.mixin.integration.mixins.RegexMethodTargetMixin;
 import net.fabricmc.tinyremapper.extension.mixin.integration.mixins.WildcardTargetMixin;
 import net.fabricmc.tinyremapper.extension.mixin.integration.targets.AmbiguousRemappedNameTarget;
 import net.fabricmc.tinyremapper.extension.mixin.integration.targets.DescAtTarget;
 import net.fabricmc.tinyremapper.extension.mixin.integration.targets.LvtRemapTarget;
 import net.fabricmc.tinyremapper.extension.mixin.integration.targets.NonObfuscatedOverrideTarget;
+import net.fabricmc.tinyremapper.extension.mixin.integration.targets.RegexMethodTarget;
 import net.fabricmc.tinyremapper.extension.mixin.integration.targets.WildcardTarget;
 
 public class MixinIntegrationTest {
@@ -121,6 +123,22 @@ public class MixinIntegrationTest {
 		});
 
 		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/Desc;(args={java.lang.String.class}, ret=int.class, value=\"at\""));
+	}
+
+	@Test
+	public void remapRegexMethodTarget() throws IOException {
+		String remapped = remap(RegexMethodTarget.class, RegexMethodTargetMixin.class, out -> {
+			String fqn = "net/fabricmc/tinyremapper/extension/mixin/integration/targets/RegexMethodTarget";
+			out.acceptClass(fqn, "com/example/Remapped");
+			out.acceptMethod(new IMappingProvider.Member(fqn, "target0", "()Ljava/lang/String;"), "t0");
+			out.acceptMethod(new IMappingProvider.Member(fqn, "target0", "(Ljava/lang/String;)Ljava/lang/String;"), "t00");
+			out.acceptMethod(new IMappingProvider.Member(fqn, "target1", "()Ljava/lang/String;"), "t1");
+			out.acceptMethod(new IMappingProvider.Member(fqn, "target2", "(Ljava/util/List;)Ljava/lang/String;"), "t2");
+			out.acceptMethod(new IMappingProvider.Member(fqn, "target3", "(Ljava/lang/String;)V"), "t3");
+			out.acceptMethod(new IMappingProvider.Member(fqn, "thing4", "()Ljava/lang/String;"), "thing");
+		});
+
+		assertTrue(remapped.contains("method={\"Lcom/example/Remapped;t0()Ljava/lang/String;\", \"Lcom/example/Remapped;t00(Ljava/lang/String;)Ljava/lang/String;\", \"Lcom/example/Remapped;t1()Ljava/lang/String;\", \"Lcom/example/Remapped;t2(Ljava/util/List;)Ljava/lang/String;\"}"));
 	}
 
 	private String remap(Class<?> target, Class<?> mixin, IMappingProvider mappings) throws IOException {

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/RegexMethodTargetMixin.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/RegexMethodTargetMixin.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016, 2018, Player, asie
+ * Copyright (c) 2026, FabricMC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.fabricmc.tinyremapper.extension.mixin.integration.mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.fabricmc.tinyremapper.extension.mixin.integration.targets.RegexMethodTarget;
+
+@Mixin(RegexMethodTarget.class)
+public class RegexMethodTargetMixin {
+	@Inject(method = "/^target/ desc=/String;$/", at = @At("RETURN"))
+	private void onTargets(CallbackInfoReturnable<String> cir) {
+	}
+}

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/targets/RegexMethodTarget.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/targets/RegexMethodTarget.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016, 2018, Player, asie
+ * Copyright (c) 2026, FabricMC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.fabricmc.tinyremapper.extension.mixin.integration.targets;
+
+import java.util.List;
+
+public class RegexMethodTarget {
+	private String target0() {
+		return "target0";
+	}
+
+	private String target0(String input) {
+		return input;
+	}
+
+	private String target1() {
+		return "target1";
+	}
+
+	private String target2(List<String> input) {
+		return input.toString();
+	}
+
+	private void target3(String input) {
+	}
+
+	private String thing4() {
+		return "thing4";
+	}
+}


### PR DESCRIPTION
Adds the capability to resolve mixin regex and remap resolved methods in method selectors.   
Passes mixin audit for fabric-api `0.149.1+26.2` with modern-yarn. 

The relevant mixin in fabric-api: https://github.com/FabricMC/fabric-api/blob/c3c10324a2b2973e6d1f9896a256f8df7f223c85/fabric-permission-api-v1/src/main/java/net/fabricmc/fabric/mixin/permission/CommandSourceStackMixin.java#L68

Resolving mixin regex in `@At.target` is not included for now and may come in a future PR. Pushing this out to get fabric-api working first. 