### PR TITLE
Support method arg name remapping in MixinExtras `@Local`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	testImplementation ('net.fabricmc:sponge-mixin:0.16.2+mixin.0.8.7') {
 		transitive = false
 	}
+	testImplementation ('io.github.llamalad7:mixinextras-common:0.5.4') {
+		transitive = false
+	}
 }
 
 java {

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/common/data/Annotation.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/common/data/Annotation.java
@@ -73,4 +73,5 @@ public final class Annotation {
 	public static final String MIXIN_EXTRAS_WRAP_WITH_CONDITION_V2 = "Lcom/llamalad7/mixinextras/injector/v2/WrapWithCondition;";
 	public static final String MIXIN_EXTRAS_DEFINITIONS = "Lcom/llamalad7/mixinextras/expression/Definitions;";
 	public static final String MIXIN_EXTRAS_DEFINITION = "Lcom/llamalad7/mixinextras/expression/Definition;";
+	public static final String MIXIN_EXTRAS_SUGAR_LOCAL = "Lcom/llamalad7/mixinextras/sugar/Local;";
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/SoftTargetMixinMethodVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/SoftTargetMixinMethodVisitor.java
@@ -32,6 +32,7 @@ import net.fabricmc.tinyremapper.extension.mixin.common.data.Constant;
 import net.fabricmc.tinyremapper.extension.mixin.common.data.MxMember;
 import net.fabricmc.tinyremapper.extension.mixin.soft.annotation.AccessorAnnotationVisitor;
 import net.fabricmc.tinyremapper.extension.mixin.soft.annotation.InvokerAnnotationVisitor;
+import net.fabricmc.tinyremapper.extension.mixin.soft.annotation.SugarLocalAnnotationVisitor;
 import net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection.DefinitionAnnotationVisitor;
 import net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection.DefinitionsAnnotationVisitor;
 import net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection.InjectAnnotationVisitor;
@@ -104,6 +105,21 @@ class SoftTargetMixinMethodVisitor extends MethodVisitor {
 			return new DefinitionsAnnotationVisitor(data, av);
 		case Annotation.MIXIN_EXTRAS_DEFINITION:
 			return new DefinitionAnnotationVisitor(data, av);
+		}
+
+		return av;
+	}
+
+	/**
+	 * This is called after visitAnnotation.
+	 */
+	@Override
+	public AnnotationVisitor visitParameterAnnotation(int parameter, String descriptor, boolean visible) {
+		AnnotationVisitor av = super.visitParameterAnnotation(parameter, descriptor, visible);
+
+		switch (descriptor) {
+		case Annotation.MIXIN_EXTRAS_SUGAR_LOCAL:
+			return new SugarLocalAnnotationVisitor(data, av, knownTargetMethods);
 		}
 
 		return av;

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/SoftTargetMixinMethodVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/SoftTargetMixinMethodVisitor.java
@@ -18,8 +18,10 @@
 
 package net.fabricmc.tinyremapper.extension.mixin.soft;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.MethodVisitor;
@@ -45,12 +47,14 @@ import net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection.WrapM
 import net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection.WrapOperationAnnotationVisitor;
 import net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection.WrapWithConditionAnnotationVisitor;
 import net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection.WrapWithConditionV2AnnotationVisitor;
+import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
 
 class SoftTargetMixinMethodVisitor extends MethodVisitor {
 	private final CommonData data;
 	private final MxMember method;
 
 	private final List<String> targets;
+	private final Set<MemberInfo> knownTargetMethods;
 
 	SoftTargetMixinMethodVisitor(CommonData data, MethodVisitor delegate, MxMember method, List<String> targets) {
 		super(Constant.ASM_VERSION, delegate);
@@ -58,6 +62,7 @@ class SoftTargetMixinMethodVisitor extends MethodVisitor {
 		this.method = Objects.requireNonNull(method);
 
 		this.targets = Objects.requireNonNull(targets);
+		this.knownTargetMethods = new HashSet<>();
 	}
 
 	@Override
@@ -70,31 +75,31 @@ class SoftTargetMixinMethodVisitor extends MethodVisitor {
 		case Annotation.INVOKER:
 			return new InvokerAnnotationVisitor(data, av, method, targets);
 		case Annotation.INJECT:
-			return new InjectAnnotationVisitor(data, av, targets);
+			return new InjectAnnotationVisitor(data, av, targets, knownTargetMethods);
 		case Annotation.MODIFY_ARG:
-			return new ModifyArgAnnotationVisitor(data, av, targets);
+			return new ModifyArgAnnotationVisitor(data, av, targets, knownTargetMethods);
 		case Annotation.MODIFY_ARGS:
-			return new ModifyArgsAnnotationVisitor(data, av, targets);
+			return new ModifyArgsAnnotationVisitor(data, av, targets, knownTargetMethods);
 		case Annotation.MODIFY_CONSTANT:
-			return new ModifyConstantAnnotationVisitor(data, av, targets);
+			return new ModifyConstantAnnotationVisitor(data, av, targets, knownTargetMethods);
 		case Annotation.MODIFY_VARIABLE:
-			return new ModifyVariableAnnotationVisitor(data, av, targets);
+			return new ModifyVariableAnnotationVisitor(data, av, targets, knownTargetMethods);
 		case Annotation.REDIRECT:
-			return new RedirectAnnotationVisitor(data, av, targets);
+			return new RedirectAnnotationVisitor(data, av, targets, knownTargetMethods);
 		case Annotation.MIXIN_EXTRAS_MODIFY_EXPRESSION_VALUE:
-			return new ModifyExpressionValueAnnotationVisitor(data, av, targets);
+			return new ModifyExpressionValueAnnotationVisitor(data, av, targets, knownTargetMethods);
 		case Annotation.MIXIN_EXTRAS_MODIFY_RECEIVER:
-			return new ModifyReceiverAnnotationVisitor(data, av, targets);
+			return new ModifyReceiverAnnotationVisitor(data, av, targets, knownTargetMethods);
 		case Annotation.MIXIN_EXTRAS_MODIFY_RETURN_VALUE:
-			return new ModifyReturnValueAnnotationVisitor(data, av, targets);
+			return new ModifyReturnValueAnnotationVisitor(data, av, targets, knownTargetMethods);
 		case Annotation.MIXIN_EXTRAS_WRAP_METHOD:
-			return new WrapMethodAnnotationVisitor(data, av, targets);
+			return new WrapMethodAnnotationVisitor(data, av, targets, knownTargetMethods);
 		case Annotation.MIXIN_EXTRAS_WRAP_OPERATION:
-			return new WrapOperationAnnotationVisitor(data, av, targets);
+			return new WrapOperationAnnotationVisitor(data, av, targets, knownTargetMethods);
 		case Annotation.MIXIN_EXTRAS_WRAP_WITH_CONDITION:
-			return new WrapWithConditionAnnotationVisitor(data, av, targets);
+			return new WrapWithConditionAnnotationVisitor(data, av, targets, knownTargetMethods);
 		case Annotation.MIXIN_EXTRAS_WRAP_WITH_CONDITION_V2:
-			return new WrapWithConditionV2AnnotationVisitor(data, av, targets);
+			return new WrapWithConditionV2AnnotationVisitor(data, av, targets, knownTargetMethods);
 		case Annotation.MIXIN_EXTRAS_DEFINITIONS:
 			return new DefinitionsAnnotationVisitor(data, av);
 		case Annotation.MIXIN_EXTRAS_DEFINITION:

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/SugarLocalAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/SugarLocalAnnotationVisitor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2016, 2018, Player, asie
+ * Copyright (c) 2026, FabricMC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.fabricmc.tinyremapper.extension.mixin.soft.annotation;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.objectweb.asm.AnnotationVisitor;
+
+import net.fabricmc.tinyremapper.api.TrMethod;
+import net.fabricmc.tinyremapper.extension.mixin.common.ResolveUtility;
+import net.fabricmc.tinyremapper.extension.mixin.common.data.AnnotationElement;
+import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+import net.fabricmc.tinyremapper.extension.mixin.common.data.Constant;
+import net.fabricmc.tinyremapper.extension.mixin.common.data.Message;
+import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
+import net.fabricmc.tinyremapper.extension.mixin.soft.util.LocalsMapper;
+
+public class SugarLocalAnnotationVisitor extends AnnotationVisitor {
+	private final CommonData data;
+	private final Set<MemberInfo> knownTargetMethods;
+
+	public SugarLocalAnnotationVisitor(CommonData data, AnnotationVisitor delegate, Set<MemberInfo> knownTargetMethods) {
+		super(Constant.ASM_VERSION, delegate);
+
+		this.data = Objects.requireNonNull(data);
+		this.knownTargetMethods = Objects.requireNonNull(knownTargetMethods);
+	}
+
+	@Override
+	public AnnotationVisitor visitArray(String name) {
+		AnnotationVisitor av = super.visitArray(name);
+
+		if (name.equals(AnnotationElement.NAME)) {
+			return new AnnotationVisitor(Constant.ASM_VERSION, av) {
+				@Override
+				public void visit(String name, Object value) {
+					String localName = Objects.requireNonNull((String) value).replaceAll("\\s", "");
+
+					List<TrMethod> targetMethods = knownTargetMethods.stream()
+							// we should already have a unique set of methods, so set FLAG_UNIQUE
+							.map(memberInfo -> data.resolver.resolveMethod(memberInfo.getOwner(), memberInfo.getName(), memberInfo.getDesc(), ResolveUtility.FLAG_UNIQUE))
+							.filter(Optional::isPresent)
+							.map(Optional::get)
+							.collect(Collectors.toList());
+
+					List<String> collection = targetMethods.stream()
+							.map(m -> LocalsMapper.mapLocal(data, m, localName))
+							.sorted().distinct().collect(Collectors.toList());
+
+					if (collection.size() > 1) {
+						data.getLogger().error(Message.CONFLICT_MAPPING, localName, collection);
+					} else if (collection.isEmpty()) {
+						data.getLogger().warn(Message.NO_MAPPING_NON_RECURSIVE, localName, targetMethods);
+					}
+
+					super.visit(name, collection.stream().findFirst().orElse(localName));
+				}
+			};
+		}
+
+		return av;
+	}
+}

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/CommonInjectionAnnotationVisitor.java
@@ -59,12 +59,14 @@ import net.fabricmc.tinyremapper.extension.mixin.soft.util.RegexMatcher;
 class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 	protected final CommonData data;
 	protected final List<String> targets;
+	protected final Set<MemberInfo> knownTargetMethods;
 
-	CommonInjectionAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets) {
+	CommonInjectionAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, Set<MemberInfo> knownTargetMethods) {
 		super(Constant.ASM_VERSION, Objects.requireNonNull(delegate));
 
 		this.data = Objects.requireNonNull(data);
 		this.targets = Objects.requireNonNull(targets);
+		this.knownTargetMethods = Objects.requireNonNull(knownTargetMethods);
 	}
 
 	@Override
@@ -120,7 +122,7 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 						return;
 					}
 
-					List<MemberInfo> resolved = new InjectMethodMappable(data, info, targets).result();
+					List<MemberInfo> resolved = new InjectMethodMappable(data, info, targets, knownTargetMethods).result();
 
 					if (resolved.isEmpty()) {
 						throw new RuntimeException("InjectMethodMappable should never resolve to zero entries");
@@ -203,6 +205,8 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 			String mappedName = data.mapper.mapName(matchedMethod);
 			String mappedDesc = data.mapper.mapDesc(matchedMethod);
 			result.add(String.format("L%s;%s%s", mappedOwner, mappedName, mappedDesc));
+
+			this.knownTargetMethods.add(new MemberInfo(matchedMethod.getOwner().getName(), matchedMethod.getName(), "", matchedMethod.getDesc()));
 		}
 
 		return result;
@@ -212,10 +216,12 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 		private final CommonData data;
 		private final MemberInfo info;
 		private final List<TrClass> targets;
+		protected final Set<MemberInfo> knownTargetMethods;
 
-		InjectMethodMappable(CommonData data, MemberInfo info, List<String> targets) {
+		InjectMethodMappable(CommonData data, MemberInfo info, List<String> targets, Set<MemberInfo> knownTargetMethods) {
 			this.data = Objects.requireNonNull(data);
 			this.info = Objects.requireNonNull(info);
+			this.knownTargetMethods = Objects.requireNonNull(knownTargetMethods);
 
 			if (info.getOwner().isEmpty()) {
 				this.targets = Objects.requireNonNull(targets).stream()
@@ -287,6 +293,8 @@ class CommonInjectionAnnotationVisitor extends AnnotationVisitor {
 
 					fullMethodToTarget.computeIfAbsent(Pair.of(mappedName, mappedDesc), k -> new HashSet<>()).add(target);
 					namesToDesc.computeIfAbsent(mappedName, k -> new TreeSet<>()).add(mappedDesc);
+
+					this.knownTargetMethods.add(new MemberInfo(target.getName(), method.getName(), "", method.getDesc()));
 				}
 			}
 

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/InjectAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/InjectAnnotationVisitor.java
@@ -19,13 +19,15 @@
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
 import java.util.List;
+import java.util.Set;
 
 import org.objectweb.asm.AnnotationVisitor;
 
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
 
 public class InjectAnnotationVisitor extends CommonInjectionAnnotationVisitor {
-	public InjectAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets) {
-		super(data, delegate, targets);
+	public InjectAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, Set<MemberInfo> knownTargetMethods) {
+		super(data, delegate, targets, knownTargetMethods);
 	}
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyArgAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyArgAnnotationVisitor.java
@@ -19,13 +19,15 @@
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
 import java.util.List;
+import java.util.Set;
 
 import org.objectweb.asm.AnnotationVisitor;
 
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
 
 public class ModifyArgAnnotationVisitor extends CommonInjectionAnnotationVisitor {
-	public ModifyArgAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets) {
-		super(data, delegate, targets);
+	public ModifyArgAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, Set<MemberInfo> knownTargetMethods) {
+		super(data, delegate, targets, knownTargetMethods);
 	}
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyArgsAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyArgsAnnotationVisitor.java
@@ -19,13 +19,15 @@
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
 import java.util.List;
+import java.util.Set;
 
 import org.objectweb.asm.AnnotationVisitor;
 
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
 
 public class ModifyArgsAnnotationVisitor extends CommonInjectionAnnotationVisitor {
-	public ModifyArgsAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets) {
-		super(data, delegate, targets);
+	public ModifyArgsAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, Set<MemberInfo> knownTargetMethods) {
+		super(data, delegate, targets, knownTargetMethods);
 	}
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyConstantAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyConstantAnnotationVisitor.java
@@ -19,13 +19,15 @@
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
 import java.util.List;
+import java.util.Set;
 
 import org.objectweb.asm.AnnotationVisitor;
 
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
 
 public class ModifyConstantAnnotationVisitor extends CommonInjectionAnnotationVisitor {
-	public ModifyConstantAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets) {
-		super(data, delegate, targets);
+	public ModifyConstantAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, Set<MemberInfo> knownTargetMethods) {
+		super(data, delegate, targets, knownTargetMethods);
 	}
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyExpressionValueAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyExpressionValueAnnotationVisitor.java
@@ -19,13 +19,15 @@
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
 import java.util.List;
+import java.util.Set;
 
 import org.objectweb.asm.AnnotationVisitor;
 
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
 
 public class ModifyExpressionValueAnnotationVisitor extends CommonInjectionAnnotationVisitor {
-	public ModifyExpressionValueAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets) {
-		super(data, delegate, targets);
+	public ModifyExpressionValueAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, Set<MemberInfo> knownTargetMethods) {
+		super(data, delegate, targets, knownTargetMethods);
 	}
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyReceiverAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyReceiverAnnotationVisitor.java
@@ -19,13 +19,15 @@
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
 import java.util.List;
+import java.util.Set;
 
 import org.objectweb.asm.AnnotationVisitor;
 
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
 
 public class ModifyReceiverAnnotationVisitor extends CommonInjectionAnnotationVisitor {
-	public ModifyReceiverAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets) {
-		super(data, delegate, targets);
+	public ModifyReceiverAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, Set<MemberInfo> knownTargetMethods) {
+		super(data, delegate, targets, knownTargetMethods);
 	}
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyReturnValueAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyReturnValueAnnotationVisitor.java
@@ -19,13 +19,15 @@
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
 import java.util.List;
+import java.util.Set;
 
 import org.objectweb.asm.AnnotationVisitor;
 
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
 
 public class ModifyReturnValueAnnotationVisitor extends CommonInjectionAnnotationVisitor {
-	public ModifyReturnValueAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets) {
-		super(data, delegate, targets);
+	public ModifyReturnValueAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, Set<MemberInfo> knownTargetMethods) {
+		super(data, delegate, targets, knownTargetMethods);
 	}
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyVariableAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyVariableAnnotationVisitor.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.objectweb.asm.AnnotationVisitor;
@@ -44,14 +45,16 @@ public class ModifyVariableAnnotationVisitor extends AnnotationNode {
 	private final CommonData data;
 	private final AnnotationVisitor delegate;
 	private final List<String> targets;
+	private final Set<MemberInfo> knownTargetMethods;
 
-	private final List<MemberInfo> methods = new ArrayList<>();
+	private final List<String> rawMethods = new ArrayList<>();
 
-	public ModifyVariableAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets) {
+	public ModifyVariableAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, Set<MemberInfo> knownTargetMethods) {
 		super(Constant.ASM_VERSION, Annotation.MODIFY_VARIABLE);
 		this.data = Objects.requireNonNull(data);
 		this.delegate = Objects.requireNonNull(delegate);
 		this.targets = Objects.requireNonNull(targets);
+		this.knownTargetMethods = Objects.requireNonNull(knownTargetMethods);
 	}
 
 	@Override
@@ -62,10 +65,8 @@ public class ModifyVariableAnnotationVisitor extends AnnotationNode {
 			return new AnnotationVisitor(Constant.ASM_VERSION, av) {
 				@Override
 				public void visit(String name, Object value) {
-					MemberInfo info = MemberInfo.parse(Objects.requireNonNull((String) value).replaceAll("\\s", ""));
-
-					if (info != null && (info.getOwner().isEmpty() || ModifyVariableAnnotationVisitor.this.targets.contains(info.getOwner()))) {
-						ModifyVariableAnnotationVisitor.this.methods.add(info);
+					if (value != null) {
+						ModifyVariableAnnotationVisitor.this.rawMethods.add((String) value);
 					}
 
 					super.visit(name, value);
@@ -78,18 +79,20 @@ public class ModifyVariableAnnotationVisitor extends AnnotationNode {
 
 	@Override
 	public void visitEnd() {
-		this.accept(new ModifyVariableSecondPassAnnotationVisitor(this.data, this.delegate, this.targets, this.methods));
+		this.accept(new ModifyVariableSecondPassAnnotationVisitor(this.data, this.delegate, this.targets, this.rawMethods, this.knownTargetMethods));
 
 		super.visitEnd();
 	}
 
 	private static class ModifyVariableSecondPassAnnotationVisitor extends CommonInjectionAnnotationVisitor {
-		private final List<MemberInfo> methods;
+		private final List<String> rawMethods;
 		private final List<TrClass> targets;
 
-		ModifyVariableSecondPassAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, List<MemberInfo> methods) {
-			super(data, delegate, targets);
-			this.methods = methods;
+		private boolean visitedMethods = false;
+
+		ModifyVariableSecondPassAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, List<String> rawMethods, Set<MemberInfo> knownTargetMethods) {
+			super(data, delegate, targets, knownTargetMethods);
+			this.rawMethods = rawMethods;
 			this.targets = Objects.requireNonNull(targets).stream()
 					.map(data.resolver::resolveClass)
 					.filter(Optional::isPresent)
@@ -99,6 +102,32 @@ public class ModifyVariableAnnotationVisitor extends AnnotationNode {
 
 		@Override
 		public AnnotationVisitor visitArray(String name) {
+			if (name.equals(AnnotationElement.METHOD)) {
+				if (visitedMethods) {
+					return null; // blackhole so we don't visit it twice
+				} else {
+					visitedMethods = true;
+				}
+			}
+
+			if (name.equals(AnnotationElement.NAME)) {
+				if (!visitedMethods) {
+					// methods must be visited before names, so force it right now
+					AnnotationVisitor annotationVisitor = this.visitArray(AnnotationElement.METHOD);
+
+					// logic borrowed from AnnotationNode.accept
+					if (annotationVisitor != null) {
+						for (String rawMethod : this.rawMethods) {
+							annotationVisitor.visit(null, rawMethod);
+						}
+
+						annotationVisitor.visitEnd();
+					}
+
+					visitedMethods = true;
+				}
+			}
+
 			AnnotationVisitor av = super.visitArray(name);
 
 			if (name.equals(AnnotationElement.NAME)) {
@@ -107,10 +136,14 @@ public class ModifyVariableAnnotationVisitor extends AnnotationNode {
 					public void visit(String name, Object value) {
 						String localName = Objects.requireNonNull((String) value).replaceAll("\\s", "");
 
-						List<String> collection = targets.stream()
-								.flatMap(target -> methods.stream().map(info -> resolvePartial(target, info.getName(), info.getDesc())))
+						List<TrMethod> targetMethods = knownTargetMethods.stream()
+								// we should already have a unique set of methods, so set FLAG_UNIQUE
+								.map(memberInfo -> data.resolver.resolveMethod(memberInfo.getOwner(), memberInfo.getName(), memberInfo.getDesc(), ResolveUtility.FLAG_UNIQUE))
 								.filter(Optional::isPresent)
 								.map(Optional::get)
+								.collect(Collectors.toList());
+
+						List<String> collection = targetMethods.stream()
 								.map(m -> {
 									TrLocal[] localVariables = m.getLocals();
 
@@ -145,7 +178,7 @@ public class ModifyVariableAnnotationVisitor extends AnnotationNode {
 						if (collection.size() > 1) {
 							data.getLogger().error(Message.CONFLICT_MAPPING, localName, collection);
 						} else if (collection.isEmpty()) {
-							data.getLogger().warn(Message.NO_MAPPING_NON_RECURSIVE, localName, targets);
+							data.getLogger().warn(Message.NO_MAPPING_NON_RECURSIVE, localName, targetMethods);
 						}
 
 						super.visit(name, collection.stream().findFirst().orElse(localName));

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyVariableAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/ModifyVariableAnnotationVisitor.java
@@ -19,9 +19,7 @@
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -31,7 +29,6 @@ import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.tree.AnnotationNode;
 
 import net.fabricmc.tinyremapper.api.TrClass;
-import net.fabricmc.tinyremapper.api.TrLocal;
 import net.fabricmc.tinyremapper.api.TrMethod;
 import net.fabricmc.tinyremapper.extension.mixin.common.ResolveUtility;
 import net.fabricmc.tinyremapper.extension.mixin.common.data.Annotation;
@@ -40,6 +37,7 @@ import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
 import net.fabricmc.tinyremapper.extension.mixin.common.data.Constant;
 import net.fabricmc.tinyremapper.extension.mixin.common.data.Message;
 import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
+import net.fabricmc.tinyremapper.extension.mixin.soft.util.LocalsMapper;
 
 public class ModifyVariableAnnotationVisitor extends AnnotationNode {
 	private final CommonData data;
@@ -144,36 +142,8 @@ public class ModifyVariableAnnotationVisitor extends AnnotationNode {
 								.collect(Collectors.toList());
 
 						List<String> collection = targetMethods.stream()
-								.map(m -> {
-									TrLocal[] localVariables = m.getLocals();
-
-									if (localVariables == null || localVariables.length == 0) {
-										return localName;
-									}
-
-									Map<String, Integer> lvtName2Index = new HashMap<>();
-
-									for (TrLocal variable : localVariables) {
-										if (!lvtName2Index.containsKey(variable.getName())) {
-											lvtName2Index.put(variable.getName(), variable.getIndex());
-										} else {
-											lvtName2Index.put(variable.getName(), -1); // TODO actually generate lvt for injection points, currently only handles unique names
-										}
-									}
-
-									if (!lvtName2Index.containsKey(localName)) {
-										return localName;
-									}
-
-									int lvIndex = lvtName2Index.get(localName);
-
-									if (lvIndex < 0) {
-										return localName;
-									}
-
-									return data.mapper.asTrRemapper().mapMethodArg(m.getOwner().getName(), m.getName(), m.getDesc(), lvIndex, localName);
-								})
-								.distinct().collect(Collectors.toList());
+								.map(m -> LocalsMapper.mapLocal(data, m, localName))
+								.sorted().distinct().collect(Collectors.toList());
 
 						if (collection.size() > 1) {
 							data.getLogger().error(Message.CONFLICT_MAPPING, localName, collection);

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/RedirectAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/RedirectAnnotationVisitor.java
@@ -19,13 +19,15 @@
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
 import java.util.List;
+import java.util.Set;
 
 import org.objectweb.asm.AnnotationVisitor;
 
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
 
 public class RedirectAnnotationVisitor extends CommonInjectionAnnotationVisitor {
-	public RedirectAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets) {
-		super(data, delegate, targets);
+	public RedirectAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, Set<MemberInfo> knownTargetMethods) {
+		super(data, delegate, targets, knownTargetMethods);
 	}
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/WrapMethodAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/WrapMethodAnnotationVisitor.java
@@ -19,13 +19,15 @@
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
 import java.util.List;
+import java.util.Set;
 
 import org.objectweb.asm.AnnotationVisitor;
 
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
 
 public class WrapMethodAnnotationVisitor extends CommonInjectionAnnotationVisitor {
-	public WrapMethodAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets) {
-		super(data, delegate, targets);
+	public WrapMethodAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, Set<MemberInfo> knownTargetMethods) {
+		super(data, delegate, targets, knownTargetMethods);
 	}
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/WrapOperationAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/WrapOperationAnnotationVisitor.java
@@ -19,13 +19,15 @@
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
 import java.util.List;
+import java.util.Set;
 
 import org.objectweb.asm.AnnotationVisitor;
 
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
 
 public class WrapOperationAnnotationVisitor extends CommonInjectionAnnotationVisitor {
-	public WrapOperationAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets) {
-		super(data, delegate, targets);
+	public WrapOperationAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, Set<MemberInfo> knownTargetMethods) {
+		super(data, delegate, targets, knownTargetMethods);
 	}
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/WrapWithConditionAnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/WrapWithConditionAnnotationVisitor.java
@@ -19,13 +19,15 @@
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
 import java.util.List;
+import java.util.Set;
 
 import org.objectweb.asm.AnnotationVisitor;
 
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
 
 public class WrapWithConditionAnnotationVisitor extends CommonInjectionAnnotationVisitor {
-	public WrapWithConditionAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets) {
-		super(data, delegate, targets);
+	public WrapWithConditionAnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, Set<MemberInfo> knownTargetMethods) {
+		super(data, delegate, targets, knownTargetMethods);
 	}
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/WrapWithConditionV2AnnotationVisitor.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/annotation/injection/WrapWithConditionV2AnnotationVisitor.java
@@ -19,13 +19,15 @@
 package net.fabricmc.tinyremapper.extension.mixin.soft.annotation.injection;
 
 import java.util.List;
+import java.util.Set;
 
 import org.objectweb.asm.AnnotationVisitor;
 
 import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+import net.fabricmc.tinyremapper.extension.mixin.soft.data.MemberInfo;
 
 public class WrapWithConditionV2AnnotationVisitor extends CommonInjectionAnnotationVisitor {
-	public WrapWithConditionV2AnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets) {
-		super(data, delegate, targets);
+	public WrapWithConditionV2AnnotationVisitor(CommonData data, AnnotationVisitor delegate, List<String> targets, Set<MemberInfo> knownTargetMethods) {
+		super(data, delegate, targets, knownTargetMethods);
 	}
 }

--- a/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/util/LocalsMapper.java
+++ b/src/main/java/net/fabricmc/tinyremapper/extension/mixin/soft/util/LocalsMapper.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2016, 2018, Player, asie
+ * Copyright (c) 2026, FabricMC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.fabricmc.tinyremapper.extension.mixin.soft.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.fabricmc.tinyremapper.api.TrLocal;
+import net.fabricmc.tinyremapper.api.TrMethod;
+import net.fabricmc.tinyremapper.extension.mixin.common.data.CommonData;
+
+public class LocalsMapper {
+	public static String mapLocal(CommonData data, TrMethod target, String localName) {
+		TrLocal[] localVariables = target.getLocals();
+
+		if (localVariables == null || localVariables.length == 0) {
+			return localName;
+		}
+
+		Map<String, Integer> lvtName2Index = new HashMap<>();
+
+		for (TrLocal variable : localVariables) {
+			if (!lvtName2Index.containsKey(variable.getName())) {
+				lvtName2Index.put(variable.getName(), variable.getIndex());
+			} else {
+				lvtName2Index.put(variable.getName(), -1); // TODO actually generate lvt for injection points, currently only handles unique names
+			}
+		}
+
+		if (!lvtName2Index.containsKey(localName)) {
+			return localName;
+		}
+
+		int lvIndex = lvtName2Index.get(localName);
+
+		if (lvIndex < 0) {
+			return localName;
+		}
+
+		return data.mapper.asTrRemapper().mapMethodArg(target.getOwner().getName(), target.getName(), target.getDesc(), lvIndex, localName);
+	}
+}

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/MixinIntegrationTest.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/MixinIntegrationTest.java
@@ -143,6 +143,7 @@ public class MixinIntegrationTest {
 		});
 
 		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/ModifyVariable;(method={\"targetRemapped\"}, at=@Lorg/spongepowered/asm/mixin/injection/At;(value=\"HEAD\"), name={\"remappedStr3\"})"));
+		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/ModifyVariable;(at=@Lorg/spongepowered/asm/mixin/injection/At;(value=\"HEAD\"), method={\"targetRemapped\"}, name={\"remappedStr3\"})"));
 	}
 
 	@Test

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/MixinIntegrationTest.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/MixinIntegrationTest.java
@@ -144,6 +144,7 @@ public class MixinIntegrationTest {
 
 		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/ModifyVariable;(method={\"targetRemapped\"}, at=@Lorg/spongepowered/asm/mixin/injection/At;(value=\"HEAD\"), name={\"remappedStr3\"})"));
 		assertTrue(remapped.contains("@Lorg/spongepowered/asm/mixin/injection/ModifyVariable;(at=@Lorg/spongepowered/asm/mixin/injection/At;(value=\"HEAD\"), method={\"targetRemapped\"}, name={\"remappedStr3\"})"));
+		assertTrue(remapped.contains("@Lcom/llamalad7/mixinextras/sugar/Local;(name={\"remappedStr3\"}, argsOnly=true) // invisible, parameter 1"));
 	}
 
 	@Test

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/LvtRemapTargetMixin.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/LvtRemapTargetMixin.java
@@ -30,4 +30,9 @@ public class LvtRemapTargetMixin {
 	private String modifyStr3(String str3) {
 		return "noice";
 	}
+
+	@ModifyVariable(at = @At("HEAD"), name = "str3", method = "target")
+	private String modifyStr3Reordered(String str3) {
+		return "noice";
+	}
 }

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/LvtRemapTargetMixin.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/LvtRemapTargetMixin.java
@@ -18,11 +18,15 @@
 
 package net.fabricmc.tinyremapper.extension.mixin.integration.mixins;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 import net.fabricmc.tinyremapper.extension.mixin.integration.targets.LvtRemapTarget;
+
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LvtRemapTarget.class)
 public class LvtRemapTargetMixin {
@@ -34,5 +38,9 @@ public class LvtRemapTargetMixin {
 	@ModifyVariable(at = @At("HEAD"), name = "str3", method = "target")
 	private String modifyStr3Reordered(String str3) {
 		return "noice";
+	}
+
+	@Inject(method = "target", at = @At("HEAD"))
+	private void captureStr3WithLocal(CallbackInfo ci, @Local(name = "str3", argsOnly = true) String str3) {
 	}
 }

--- a/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/LvtRemapTargetMixin.java
+++ b/src/test/java/net/fabricmc/tinyremapper/extension/mixin/integration/mixins/LvtRemapTargetMixin.java
@@ -23,10 +23,9 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.fabricmc.tinyremapper.extension.mixin.integration.targets.LvtRemapTarget;
-
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LvtRemapTarget.class)
 public class LvtRemapTargetMixin {


### PR DESCRIPTION
This PR adds method arg name remapping in `@Local` from MixinExtras. Passes mixin audit on modern-yarn for fabric-api `0.153.0+26.2`. 

As a side effect, this also fixes `@ModifyVariable` remap with target methods specified as mixin regex. 
